### PR TITLE
Allow pass 'multiline:false' to 'Composer' component

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -343,7 +343,7 @@ class GiftedChat extends React.Component {
     if(e.nativeEvent && e.nativeEvent.contentSize){
       newComposerHeight = Math.max(MIN_COMPOSER_HEIGHT, Math.min(MAX_COMPOSER_HEIGHT, e.nativeEvent.contentSize.height));
     }else{
-      newComposerHeight = Math.max(MIN_COMPOSER_HEIGHT, MAX_COMPOSER_HEIGHT)
+      newComposerHeight = MIN_COMPOSER_HEIGHT
     }
     
     const newMessagesContainerHeight = this.getMaxHeight() - this.calculateInputToolbarHeight(newComposerHeight) - this.getKeyboardHeight() + this.props.bottomOffset;

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -338,7 +338,14 @@ class GiftedChat extends React.Component {
     if (this.getIsTypingDisabled() === true) {
       return;
     }
-    const newComposerHeight = Math.max(MIN_COMPOSER_HEIGHT, Math.min(MAX_COMPOSER_HEIGHT, e.nativeEvent.contentSize.height));
+    
+    let newComposerHeight = null
+    if(e.nativeEvent && e.nativeEvent.contentSize){
+      newComposerHeight = Math.max(MIN_COMPOSER_HEIGHT, Math.min(MAX_COMPOSER_HEIGHT, e.nativeEvent.contentSize.height));
+    }else{
+      newComposerHeight = Math.max(MIN_COMPOSER_HEIGHT, MAX_COMPOSER_HEIGHT)
+    }
+    
     const newMessagesContainerHeight = this.getMaxHeight() - this.calculateInputToolbarHeight(newComposerHeight) - this.getKeyboardHeight() + this.props.bottomOffset;
     const newText = e.nativeEvent.text;
     this.setState((previousState) => {

--- a/src/Message.js
+++ b/src/Message.js
@@ -62,12 +62,17 @@ export default class Message extends React.Component {
   }
 
   renderAvatar() {
+    const avatarProps = {
+      ...this.props,
+      isSameUser: this.isSameUser,
+      isSameDay: this.isSameDay,
+    };
+    
+    if(this.props.renderAvatar){
+      return this.props.renderAvatar(avatartProps)
+    }
+
     if (this.props.user._id !== this.props.currentMessage.user._id) {
-      const avatarProps = {
-        ...this.props,
-        isSameUser: this.isSameUser,
-        isSameDay: this.isSameDay,
-      };
       return <Avatar {...avatarProps}/>;
     }
     return null;

--- a/src/Message.js
+++ b/src/Message.js
@@ -67,9 +67,9 @@ export default class Message extends React.Component {
       isSameUser: this.isSameUser,
       isSameDay: this.isSameDay,
     };
-    
+
     if(this.props.renderAvatar){
-      return this.props.renderAvatar(avatartProps)
+      return this.props.renderAvatar(avatarProps)
     }
 
     if (this.props.user._id !== this.props.currentMessage.user._id) {


### PR DESCRIPTION
I try to pass render custom composer param.
When i pass `multiline:false` to the composer , i got a red box.

![2016-08-15 2 09 10](https://cloud.githubusercontent.com/assets/670114/17651018/95eab2fc-628f-11e6-9ce6-b1bda3b69f4b.JPEG)

'e.nativeEvent.contentSize' is not exist when `multiline` param set to false.
So i fix this problem. ( oh my pool english ........)
