### PR TITLE
add day format as calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [example/App.js](example/App.js)
 - **`user`** _(Object)_ - user sending the messages `{_id, name, avatar}`
 - **`onSend`** _(Function)_ - function to call when sending a message
 - **`locale`** _(String)_ - localize the dates
+- **`dayFormat`** _(Object)_ - format for day. `{sameDay, nextDay, lastDay, nextWeek, lastWeek, sameElse}`. Can be used with locale. `{en: {sameDay,...}, ru: {sameDay,...}}`. Pass `null` to have default output of calendar function of momentjs.
 - **`isAnimated`** _(Bool)_ - animates the view when the keyboard appears
 - **`loadEarlier`** _(Bool)_ - enables the load earlier message button
 - **`onLoadEarlier`** _(Function)_ - function to call when loading earlier messages

--- a/src/Day.js
+++ b/src/Day.js
@@ -8,13 +8,22 @@ import {
 import moment from 'moment/min/moment-with-locales.min';
 
 export default class Day extends React.Component {
+  dayFormat() {
+    if( this.props.dayFormat ) {
+      var locale = this.context.getLocale();
+      return this.props.dayFormat[locale] || this.props.dayFormat;
+    } else {
+      return null;
+    }
+  }
+
   render() {
     if (!this.props.isSameDay(this.props.currentMessage, this.props.previousMessage)) {
       return (
         <View style={[styles.container, this.props.containerStyle]}>
           <View style={[styles.wrapper, this.props.wrapperStyle]}>
             <Text style={[styles.text, this.props.textStyle]}>
-              {moment(this.props.currentMessage.createdAt).locale(this.context.getLocale()).format('ll').toUpperCase()}
+              {moment(this.props.currentMessage.createdAt).locale(this.context.getLocale()).calendar(null, this.dayFormat()).toUpperCase()}
             </Text>
           </View>
         </View>
@@ -61,6 +70,14 @@ Day.defaultProps = {
     createdAt: null,
   },
   previousMessage: {},
+  dayFormat: {
+    sameDay: 'll',
+    nextDay: 'll',
+    lastDay: 'll',
+    nextWeek: 'll',
+    lastWeek: 'll',
+    sameElse: 'll',
+  },
 };
 
 Day.propTypes = {
@@ -70,4 +87,5 @@ Day.propTypes = {
   isSameDay: React.PropTypes.func,
   currentMessage: React.PropTypes.object,
   previousMessage: React.PropTypes.object,
+  dayFormat: React.PropTypes.object,
 };


### PR DESCRIPTION
I saved format of current version of Day and added ability to pass dayFormat to use in calendar() of moment.

Hence we can have 'TODAY', 'YESTERDAY' etc. Instead of '16 Aug. 2016' when it was yesterday