### PR TITLE
fix footer re-render

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -62,7 +62,7 @@ export default class MessageContainer extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.messages === nextProps.messages) {
+    if (this.props.messages === nextProps.messages && this.props === nextProps) {
       return;
     }
     const messagesData = this.prepareMessages(nextProps.messages);


### PR DESCRIPTION
Hello!

I've got a
```
renderFooter: ->
    if @state.typingText?
      <View style={styles.footerContainer}>
      ...
    else
      null
```
function. But it's not triggered when I update `typingText` in `state`.
Only when messages replaced/updated.

IMO it's wrong behaviour.
But maybe you can tell some advices/thoughts if this PR is right?