### PR TITLE
Fix unnecessary warning when message.id === 0

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -101,7 +101,7 @@ export default class MessageContainer extends React.Component {
   }
 
   renderRow(message, sectionId, rowId) {
-    if (!message._id) {
+    if (!message._id && message._id !== 0) {
       console.warn('GiftedChat: `_id` is missing for message', JSON.stringify(message));
     }
     if (!message.user) {


### PR DESCRIPTION
`0` evaluates to `false`, so this warning will appear for anyone using a 0-based array index for their messages.

Alternative syntax could be `if (!(message._id || message._id === 0))`, if you have any particular preference for readability.