### PR TITLE
Add accessibilityTraits to support screen readers

### DIFF
--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -101,6 +101,7 @@ export default class Bubble extends React.Component {
         <View style={[styles[this.props.position].wrapper, this.props.wrapperStyle[this.props.position], this.handleBubbleToNext(), this.handleBubbleToPrevious()]}>
           <TouchableWithoutFeedback
             onLongPress={this.onLongPress}
+            accessibilityTraits="text"
             {...this.props.touchableProps}
           >
             <View>

--- a/src/Composer.js
+++ b/src/Composer.js
@@ -19,6 +19,7 @@ export default class Composer extends React.Component {
           height: this.props.composerHeight,
         }]}
         value={this.props.text}
+        accessibilityLabel={this.props.text || this.props.placeholder}
         enablesReturnKeyAutomatically={true}
         underlineColorAndroid="transparent"
         {...this.props.textInputProps}

--- a/src/GiftedAvatar.js
+++ b/src/GiftedAvatar.js
@@ -71,11 +71,14 @@ export default class GiftedAvatar extends React.Component {
     if (!this.props.user.name && !this.props.user.avatar) {
       // render placeholder
       return (
-        <View style={[
-          defaultStyles.avatarStyle,
-          {backgroundColor: 'transparent'},
-          this.props.avatarStyle,
-        ]}/>
+        <View
+          style={[
+            defaultStyles.avatarStyle,
+            {backgroundColor: 'transparent'},
+            this.props.avatarStyle,
+          ]}
+          accessibilityTraits="image"
+        />
       )
     }
     if (this.props.user.avatar) {
@@ -86,6 +89,7 @@ export default class GiftedAvatar extends React.Component {
             const {onPress, ...other} = this.props;
             this.props.onPress && this.props.onPress(other);
           }}
+          accessibilityTraits="image"
         >
           {this.renderAvatar()}
         </TouchableOpacity>
@@ -108,6 +112,7 @@ export default class GiftedAvatar extends React.Component {
           {backgroundColor: this.avatarColor},
           this.props.avatarStyle,
         ]}
+        accessibilityTraits="image"
       >
         {this.renderInitials()}
       </TouchableOpacity>

--- a/src/LoadEarlier.js
+++ b/src/LoadEarlier.js
@@ -42,6 +42,7 @@ export default class LoadEarlier extends React.Component {
           }
         }}
         disabled={this.props.isLoadingEarlier === true}
+        accessibilityTraits="button"
       >
         <View style={[styles.wrapper, this.props.wrapperStyle]}>
           {this.renderLoading()}

--- a/src/Send.js
+++ b/src/Send.js
@@ -21,6 +21,7 @@ export default class Send extends React.Component {
           onPress={() => {
             this.props.onSend({text: this.props.text.trim()}, true);
           }}
+          accessibilityTraits="button"
         >
           <Text style={[styles.text, this.props.textStyle]}>{this.props.label}</Text>
         </TouchableOpacity>


### PR DESCRIPTION
Using `accessibilityTraits="button"`, for example, allows screen readers like Voiceover or TalkBack to behave more appropriately. See the [React Native](https://facebook.github.io/react-native/docs/accessibility.html) or [Apple](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/iPhoneAccessibility/Making_Application_Accessible/Making_Application_Accessible.html#//apple_ref/doc/uid/TP40008785-CH102-SW7) guides for more info.