### PR TITLE
Align messages from the top

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -139,6 +139,7 @@ export default class MessageContainer extends React.Component {
     return (
       <View ref='container' style={{flex:1}}>
         <ListView
+          contentContainerStyle={{flex: 1, justifyContent: 'flex-end'}}
           enableEmptySections={true}
           keyboardShouldPersistTaps={true}
           automaticallyAdjustContentInsets={false}


### PR DESCRIPTION
Here is the fix for #181 using the solution provided by ide (https://github.com/exponentjs/react-native-invertible-scroll-view/issues/11)