### PR TITLE
Set send setTimeout to 0

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -327,7 +327,7 @@ class GiftedChat extends React.Component {
         if (this.getIsMounted() === true) {
           this.setIsTypingDisabled(false);
         }
-      }, 200);
+      }, 0);
     }
   }
 


### PR DESCRIPTION
Currently messages can be cleared if you're in the middle of typing the
next message when setTimeout resets the toolbar