### PR TITLE
Expose GiftedAvatar

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -24,6 +24,7 @@ import Message from './Message';
 import MessageContainer from './MessageContainer';
 import Send from './Send';
 import Time from './Time';
+import GiftedAvatar from './GiftedAvatar';
 
 // Min and max heights of ToolbarInput and Composer
 // Needed for Composer auto grow and ScrollView animation
@@ -542,4 +543,5 @@ export {
   Message,
   Send,
   Time,
+  GiftedAvatar,
 };


### PR DESCRIPTION
Export  `GiftedAvatar` in `GiftedChat.js` so as to be able to use `GiftedAvatar` without all the logic of `Avatar`.
