### PR TITLE
Support for orientation changes.

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -154,7 +154,14 @@ class GiftedChat extends React.Component {
   }
 
   getKeyboardHeight() {
-    return this._keyboardHeight;
+    if (Platform.OS === 'android') {
+      // For android: on-screen keyboard resized main container and has own height.
+      // @see https://developer.android.com/training/keyboard-input/visibility.html
+      // So for calculate the messages container height ignore keyboard height.
+      return 0;
+    } else {
+      return this._keyboardHeight;
+    }
   }
 
   setBottomOffset(value) {
@@ -411,15 +418,13 @@ class GiftedChat extends React.Component {
           <View
             style={styles.container}
             onLayout={(e) => {
-              if (Platform.OS === 'android') {
-                // fix an issue when keyboard is dismissing during the initialization
-                const layout = e.nativeEvent.layout;
-                if (this.getMaxHeight() !== layout.height && this.getIsFirstLayout() === true) {
-                  this.setMaxHeight(layout.height);
-                  this.setState({
-                    messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight()),
-                  });
-                }
+              // fix an issue when keyboard is dismissing during the initialization
+              const layout = e.nativeEvent.layout;
+              if (this.getMaxHeight() !== layout.height || this.getIsFirstLayout() === true) {
+                this.setMaxHeight(layout.height);
+                this.setState({
+                  messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight()),
+                });
               }
               if (this.getIsFirstLayout() === true) {
                 this.setIsFirstLayout(false);


### PR DESCRIPTION
Turned on onLayout handler for all platforms.

Android only: on-screen keyboard resized main container and has own height.
https://developer.android.com/training/keyboard-input/visibility.html
So for calculate the messages container height need ignore keyboard height.


Current problem after orientation changes:
![current_1](https://cloud.githubusercontent.com/assets/804867/20259648/3455046e-aa80-11e6-92c7-c37ec7eda71f.png)
![current_2](https://cloud.githubusercontent.com/assets/804867/20259650/345778b6-aa80-11e6-8166-5ab8c3f5895f.png)

With our fix: 
![after_fix_1](https://cloud.githubusercontent.com/assets/804867/20259647/3454e312-aa80-11e6-8da7-12b4e3f0d7de.png)
![after_fix_2](https://cloud.githubusercontent.com/assets/804867/20259649/34563438-aa80-11e6-81d8-b2efacff65ff.png)

