### PR TITLE
Added "alwaysRenderAvatar" prop to "Avatar.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See [example/App.js](example/App.js)
 - **`renderSend`** _(Function)_ - render the send button
 - **`renderAccessory`** _(Function)_ - renders a second line of actions below the message composer
 - **`bottomOffset`** _(Integer)_ - distance of the chat from the bottom of the screen, useful if you display a tab bar
-- **`alwaysRenderAvatar`** _(Bool)_ - always render the message avatar, even when consecutive messages are from same day and same user
+- **`alwaysRenderAvatar`** _(Bool)_ - always render the message avatar, even when consecutive messages are from same day and same user. The default value is `false`.
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ See [example/App.js](example/App.js)
 - **`renderSend`** _(Function)_ - render the send button
 - **`renderAccessory`** _(Function)_ - renders a second line of actions below the message composer
 - **`bottomOffset`** _(Integer)_ - distance of the chat from the bottom of the screen, useful if you display a tab bar
+- **`alwaysRenderAvatar`** _(Bool)_ - always render the message avatar, even when consecutive messages are from same day and same user
 
 
 ## Features

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -23,7 +23,7 @@ export default class Avatar extends React.Component {
 
   render() {
     if (
-      this.props.hideAvatarWhenSameDayAndUser &&
+      !this.props.alwaysRenderAvatar &&
       this.props.isSameUser(this.props.currentMessage, this.props.nextMessage) &&
       this.props.isSameDay(this.props.currentMessage, this.props.nextMessage)
     ) {
@@ -67,7 +67,7 @@ const styles = {
 };
 
 Avatar.defaultProps = {
-  hideAvatarWhenSameDayAndUser: true,
+  alwaysRenderAvatar: false,
   isSameDay: () => {},
   isSameUser: () => {},
   position: 'left',
@@ -80,7 +80,7 @@ Avatar.defaultProps = {
 };
 
 Avatar.propTypes = {
-  hideAvatarWhenSameDayAndUser: React.PropTypes.bool,
+  alwaysRenderAvatar: React.PropTypes.bool,
   isSameDay: React.PropTypes.func,
   isSameUser: React.PropTypes.func,
   position: React.PropTypes.oneOf(['left', 'right']),

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -22,7 +22,11 @@ export default class Avatar extends React.Component {
   }
 
   render() {
-    if (this.props.isSameUser(this.props.currentMessage, this.props.nextMessage) && this.props.isSameDay(this.props.currentMessage, this.props.nextMessage)) {
+    if (
+      this.props.hideAvatarWhenSameDayAndUser &&
+      this.props.isSameUser(this.props.currentMessage, this.props.nextMessage) &&
+      this.props.isSameDay(this.props.currentMessage, this.props.nextMessage)
+    ) {
       return (
         <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
           <GiftedAvatar
@@ -63,6 +67,7 @@ const styles = {
 };
 
 Avatar.defaultProps = {
+  hideAvatarWhenSameDayAndUser: true,
   isSameDay: () => {},
   isSameUser: () => {},
   position: 'left',
@@ -75,6 +80,7 @@ Avatar.defaultProps = {
 };
 
 Avatar.propTypes = {
+  hideAvatarWhenSameDayAndUser: React.PropTypes.bool,
   isSameDay: React.PropTypes.func,
   isSameUser: React.PropTypes.func,
   position: React.PropTypes.oneOf(['left', 'right']),


### PR DESCRIPTION
Currently, the `Avatar` component hides the avatar of a message if it's from the same day and from the same user of the previous message.

This prop allows users to disable this behavior, so that the avatar is rendered on all messages.

The default value is `false`, which keeps the current behavior.

In order to render the avatar on all messages, one should set the `alwaysRenderAvatar` prop to `true` when placing the `GiftedChat` component.