### PR TITLE
Add prop onInputTextChanged on GiftedChat API and help fix #286

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See [example/App.js](example/App.js)
 - **`renderSend`** _(Function)_ - render the send button
 - **`renderAccessory`** _(Function)_ - renders a second line of actions below the message composer
 - **`bottomOffset`** _(Integer)_ - distance of the chat from the bottom of the screen, useful if you display a tab bar
-
+- **`onInputTextChanged`** _(Function)_ - function that will be called when input text changes
 
 ## Features
 - Custom components

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -350,6 +350,10 @@ class GiftedChat extends React.Component {
       return;
     }
 
+    if (this.props.onInputTextChanged) {
+      this.props.onInputTextChanged(e.nativeEvent.text);
+    }
+
     let newComposerHeight = null;
     if (e.nativeEvent && e.nativeEvent.contentSize) {
       newComposerHeight = Math.max(MIN_COMPOSER_HEIGHT, Math.min(MAX_COMPOSER_HEIGHT, e.nativeEvent.contentSize.height));
@@ -502,6 +506,7 @@ GiftedChat.defaultProps = {
 GiftedChat.propTypes = {
   messages: React.PropTypes.array,
   onSend: React.PropTypes.func,
+  onInputTextChanged: React.PropTypes.func,
   loadEarlier: React.PropTypes.bool,
   onLoadEarlier: React.PropTypes.func,
   locale: React.PropTypes.string,


### PR DESCRIPTION
This introduces a new prop : onInputTextChanged on GiftedChat API,
which is a callback function that will give whatever text is present currently in Composer back to user.

* Composer has onChange prop but it is kind of consumed by onType function in GiftedChat.js.
This will also help fix #286, where you see GiftedChat.js personally uses onChange,
and the behaviour such as height calculation would have to be performed by library user (which right now happens in onType in GiftedChat.js)

* This prop gives users a simpler interface to track change in input text, with all other features intact.

Kindly guide with suggestions/comments wherever feels necessary.
Thank you.