### PR TITLE
Add lightbox for enlarging chat images

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ See [example/App.js](example/App.js)
 - **`renderMessage`** _(Function)_ - render the message container
 - **`renderMessageText`** _(Function)_ - render the message text
 - **`renderMessageImage`** _(Function)_ - render the message image
+- **`imageProps`** _(Object)_ - extra props to be passed to the [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component created by the default `renderMessageImage`
 - **`renderCustomView`** _(Function)_ - render a custom view inside the bubble
 - **`renderDay`** _(Function)_ - render the day above a message
 - **`renderTime`** _(Function)_ - render the message time

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ See [example/App.js](example/App.js)
 - **`renderMessageText`** _(Function)_ - render the message text
 - **`renderMessageImage`** _(Function)_ - render the message image
 - **`imageProps`** _(Object)_ - extra props to be passed to the [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component created by the default `renderMessageImage`
+- **`lightboxProps`** _(Object)_ - extra props to be passed to the MessageImage's [Lightbox](https://github.com/oblador/react-native-lightbox)
 - **`renderCustomView`** _(Function)_ - render a custom view inside the bubble
 - **`renderDay`** _(Function)_ - render the day above a message
 - **`renderTime`** _(Function)_ - render the message time

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-communications": "^2.1.0",
     "react-native-dismiss-keyboard": "^1.0.0",
     "react-native-invertible-scroll-view": "^1.0.0",
-    "react-native-lightbox": "^0.6.0",
+    "react-native-lightbox": "oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875",
     "react-native-parsed-text": "^0.0.15",
     "shallowequal": "^0.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-native-communications": "^2.1.0",
     "react-native-dismiss-keyboard": "^1.0.0",
     "react-native-invertible-scroll-view": "^1.0.0",
+    "react-native-lightbox": "^0.6.0",
     "react-native-parsed-text": "^0.0.15",
     "shallowequal": "^0.2.2"
   }

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -20,6 +20,7 @@ export default class MessageImage extends React.Component {
           }}
         >
           <Image
+            {...this.props.imageProps}
             style={[styles.image, this.props.imageStyle]}
             source={{uri: this.props.currentMessage.image}}
           />
@@ -50,6 +51,7 @@ MessageImage.defaultProps = {
   },
   containerStyle: {},
   imageStyle: {},
+  imageProps: {},
   navigator: null,
 };
 
@@ -57,5 +59,6 @@ MessageImage.propTypes = {
   currentMessage: React.PropTypes.object,
   containerStyle: View.propTypes.style,
   imageStyle: Image.propTypes.style,
+  imageProps: React.PropTypes.object,
   navigator: React.PropTypes.object,
 };

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -14,10 +14,10 @@ export default class MessageImage extends React.Component {
     return (
       <View style={[styles.container, this.props.containerStyle]}>
         <Lightbox
-          navigator={this.props.navigator}
           activeProps={{
             style: [styles.imageActive, { width, height }],
           }}
+          {...this.props.lightboxProps}
         >
           <Image
             {...this.props.imageProps}
@@ -52,7 +52,7 @@ MessageImage.defaultProps = {
   containerStyle: {},
   imageStyle: {},
   imageProps: {},
-  navigator: null,
+  lightboxProps: {},
 };
 
 MessageImage.propTypes = {
@@ -60,5 +60,5 @@ MessageImage.propTypes = {
   containerStyle: View.propTypes.style,
   imageStyle: Image.propTypes.style,
   imageProps: React.PropTypes.object,
-  navigator: React.PropTypes.object,
+  lightboxProps: React.PropTypes.object,
 };

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -3,16 +3,27 @@ import {
   Image,
   StyleSheet,
   View,
+  Dimensions,
 } from 'react-native';
+import Lightbox from 'react-native-lightbox';
 
 export default class MessageImage extends React.Component {
   render() {
+    const { width, height } = Dimensions.get('window');
+
     return (
       <View style={[styles.container, this.props.containerStyle]}>
-        <Image
-          style={[styles.image, this.props.imageStyle]}
-          source={{uri: this.props.currentMessage.image}}
-        />
+        <Lightbox
+          navigator={this.props.navigator}
+          activeProps={{
+            style: [styles.imageActive, { width, height }],
+          }}
+        >
+          <Image
+            style={[styles.image, this.props.imageStyle]}
+            source={{uri: this.props.currentMessage.image}}
+          />
+        </Lightbox>
       </View>
     );
   }
@@ -27,6 +38,9 @@ const styles = StyleSheet.create({
     borderRadius: 13,
     margin: 3,
     resizeMode: 'cover',
+  },
+  imageActive: {
+    resizeMode: 'contain',
   },
 });
 

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -50,10 +50,12 @@ MessageImage.defaultProps = {
   },
   containerStyle: {},
   imageStyle: {},
+  navigator: null,
 };
 
 MessageImage.propTypes = {
   currentMessage: React.PropTypes.object,
   containerStyle: View.propTypes.style,
   imageStyle: Image.propTypes.style,
+  navigator: React.PropTypes.object,
 };


### PR DESCRIPTION
Images sent in messages will be enlarged when you tap them.

Also adds 2 new props: `imageProps` and `lightboxProps`. These will be passed through to the `<Image>` and `<Lightbox>`, respectively. For example, you can now specify an image [`onLoad`](https://facebook.github.io/react-native/docs/image.html#onload) callback.

Tested and verified on iOS and Android.

---

Note: Uses a commit hash instead of version number in order to fix a warning on Android that's currently unpublished.

You can read more about react-native-lightbox [here](https://github.com/oblador/react-native-lightbox) :tropical_drink: