### PR TITLE
Add eslint script (extends airbnb + react + react-native)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+android
+ios

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,12 @@
 {
-  "plugins": [
-    "react",
-    "react-native"
-  ],
-  "extends": ["eslint:recommended", "plugin:react/recommended"],
-  "parserOptions": {
-    "sourceType": "module",
-    "ecmaFeatures" : {
-      experimentalObjectRestSpread: true
-    }
-  },
+  "extends": "cooperka/react-native",
+
   "env": {
-    "node": true
-  }
+    "browser": true,
+    "jest": true
+  },
+
+  // Any rules here will override those from
+  // https://github.com/cooperka/eslint-config-cooperka.
+  "rules": {}
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,17 @@
     "url": "https://github.com/FaridSafi/react-native-gifted-chat/issues"
   },
   "homepage": "https://github.com/FaridSafi/react-native-gifted-chat#readme",
+  "scripts": {
+    "lint": "eslint . --ext .js,.jsx"
+  },
   "devDependencies": {
-    "eslint": "^3.2.2",
-    "eslint-plugin-react": "^6.0.0",
-    "eslint-plugin-react-native": "^2.0.0"
+    "eslint": "~3.12.2",
+    "eslint-config-airbnb": "~13.0.0",
+    "eslint-config-cooperka": "~0.2.2",
+    "eslint-plugin-import": "~2.2.0",
+    "eslint-plugin-jsx-a11y": "~2.2.3",
+    "eslint-plugin-react": "~6.8.0",
+    "eslint-plugin-react-native": "~2.2.1"
   },
   "dependencies": {
     "@exponent/react-native-action-sheet": "git+https://github.com/FaridSafi/react-native-action-sheet.git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "eslint": "~3.12.2",
     "eslint-config-airbnb": "~13.0.0",
-    "eslint-config-cooperka": "~0.2.2",
+    "eslint-config-cooperka": "~0.2.3",
     "eslint-plugin-import": "~2.2.0",
     "eslint-plugin-jsx-a11y": "~2.2.3",
     "eslint-plugin-react": "~6.8.0",


### PR DESCRIPTION
Currently 486 errors, 7 warnings!

We'll have to go through and iteratively fix all of them. Most popular IDEs have an ESLint plugin where the lints will show up as red underlines, so that makes things much easier. There's also an automatic cleanup with `eslint --fix` that I haven't tried yet.

Some issues should be ignored, and that can be done line-by-line with `// eslint-disable-line rule-name` or for blocks with `/* eslint-disable rule-name */ ...code... /* eslint-enable */`

The README for [eslint-config-cooperka](https://github.com/cooperka/eslint-config-cooperka) has also been updated with config steps in case you want to have a look.