### PR TITLE
move all exports into index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,32 @@
-export * from './src/GiftedChat';
+import GiftedChat from './src/GiftedChat';
+import Actions from './src/Actions';
+import Avatar from './src/Avatar';
+import Bubble from './src/Bubble';
+import MessageImage from './src/MessageImage';
+import MessageText from './src/MessageText';
+import Composer from './src/Composer';
+import Day from './src/Day';
+import InputToolbar from './src/InputToolbar';
+import LoadEarlier from './src/LoadEarlier';
+import Message from './src/Message';
+import MessageContainer from './src/MessageContainer';
+import Send from './src/Send';
+import Time from './src/Time';
+import * as utils from './src/utils';
+
+export {
+  GiftedChat,
+  Actions,
+  Avatar,
+  Bubble,
+  MessageImage,
+  MessageText,
+  Composer,
+  Day,
+  InputToolbar,
+  LoadEarlier,
+  Message,
+  Send,
+  Time,
+  utils
+};

--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -119,7 +119,7 @@ export default class Bubble extends React.Component {
   }
 }
 
-const styles = {
+export const styles = {
   left: StyleSheet.create({
     container: {
       flex: 1,

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -11,20 +11,8 @@ import ActionSheet from '@exponent/react-native-action-sheet';
 import dismissKeyboard from 'react-native-dismiss-keyboard';
 import moment from 'moment/min/moment-with-locales.min';
 
-import * as utils from './utils';
-import Actions from './Actions';
-import Avatar from './Avatar';
-import Bubble from './Bubble';
-import MessageImage from './MessageImage';
-import MessageText from './MessageText';
-import Composer from './Composer';
-import Day from './Day';
 import InputToolbar from './InputToolbar';
-import LoadEarlier from './LoadEarlier';
-import Message from './Message';
 import MessageContainer from './MessageContainer';
-import Send from './Send';
-import Time from './Time';
 
 // Min and max heights of ToolbarInput and Composer
 // Needed for Composer auto grow and ScrollView animation
@@ -36,7 +24,7 @@ const MIN_COMPOSER_HEIGHT = Platform.select({
 const MAX_COMPOSER_HEIGHT = 100;
 const MIN_INPUT_TOOLBAR_HEIGHT = 44;
 
-class GiftedChat extends React.Component {
+export default class GiftedChat extends React.Component {
   constructor(props) {
     super(props);
 
@@ -527,21 +515,4 @@ GiftedChat.propTypes = {
   user: React.PropTypes.object,
   bottomOffset: React.PropTypes.number,
   isLoadingEarlier: React.PropTypes.bool,
-};
-
-export {
-  GiftedChat,
-  Actions,
-  Avatar,
-  Bubble,
-  MessageImage,
-  MessageText,
-  Composer,
-  Day,
-  InputToolbar,
-  LoadEarlier,
-  Message,
-  Send,
-  Time,
-  utils
 };


### PR DESCRIPTION
Allows selective imports (tree shaking).

before `import GiftedChat from 'GiftedChat/src/GiftedChat'` imported all react classes.

after: `import GiftedChat from 'GiftedChat/src/GiftedChat'` only imports GiftedChat class.

This allows selectively replace GiftedChat components for alternative implementations, without need to fork whole project.