### PR TITLE
Remove touch events and external keyboard dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,8 +7,8 @@
     "sync": "rm -rf ./node_modules/react-native-gifted-chat; sane '/usr/bin/rsync -v -a --exclude .git --exclude example --exclude __tests__ --exclude node_modules ../ ./node_modules/react-native-gifted-chat/' .. --glob='{**/*.json,**/*.js}'"
   },
   "dependencies": {
-    "react": "15.4.1",
-    "react-native": "0.39.0",
+    "react": "15.3.2",
+    "react-native": "0.37.0",
     "react-native-camera-roll-picker": "^1.1.7",
     "react-native-gifted-chat": "file:../",
     "react-native-nav": "^1.1.4"

--- a/example/package.json
+++ b/example/package.json
@@ -7,8 +7,8 @@
     "sync": "rm -rf ./node_modules/react-native-gifted-chat; sane '/usr/bin/rsync -v -a --exclude .git --exclude example --exclude __tests__ --exclude node_modules ../ ./node_modules/react-native-gifted-chat/' .. --glob='{**/*.json,**/*.js}'"
   },
   "dependencies": {
-    "react": "15.2.1",
-    "react-native": "^0.30.0",
+    "react": "15.4.1",
+    "react-native": "0.39.0",
     "react-native-camera-roll-picker": "^1.1.7",
     "react-native-gifted-chat": "file:../",
     "react-native-nav": "^1.1.4"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "md5": "^2.1.0",
     "moment": "^2.13.0",
     "react-native-communications": "^2.1.0",
-    "react-native-dismiss-keyboard": "^1.0.0",
     "react-native-invertible-scroll-view": "^1.0.0",
     "react-native-parsed-text": "^0.0.15",
     "shallowequal": "^0.2.2"

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -5,7 +5,6 @@ import {
   Platform,
   StyleSheet,
   View,
-  // Keyboard,
 } from 'react-native';
 
 import ActionSheet from '@exponent/react-native-action-sheet';

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -5,10 +5,10 @@ import {
   Platform,
   StyleSheet,
   View,
+  // Keyboard,
 } from 'react-native';
 
 import ActionSheet from '@exponent/react-native-action-sheet';
-import dismissKeyboard from 'react-native-dismiss-keyboard';
 import moment from 'moment/min/moment-with-locales.min';
 
 import * as utils from './utils';
@@ -55,9 +55,6 @@ class GiftedChat extends React.Component {
       isInitialized: false, // initialization will calculate maxHeight before rendering the chat
     };
 
-    this.onTouchStart = this.onTouchStart.bind(this);
-    this.onTouchMove = this.onTouchMove.bind(this);
-    this.onTouchEnd = this.onTouchEnd.bind(this);
     this.onKeyboardWillShow = this.onKeyboardWillShow.bind(this);
     this.onKeyboardWillHide = this.onKeyboardWillHide.bind(this);
     this.onKeyboardDidShow = this.onKeyboardDidShow.bind(this);
@@ -68,10 +65,6 @@ class GiftedChat extends React.Component {
 
     this.invertibleScrollViewProps = {
       inverted: true,
-      keyboardShouldPersistTaps: true,
-      onTouchStart: this.onTouchStart,
-      onTouchMove: this.onTouchMove,
-      onTouchEnd: this.onTouchEnd,
       onKeyboardWillShow: this.onKeyboardWillShow,
       onKeyboardWillHide: this.onKeyboardWillHide,
       onKeyboardDidShow: this.onKeyboardDidShow,
@@ -263,22 +256,6 @@ class GiftedChat extends React.Component {
       y: 0,
       animated,
     });
-  }
-
-  onTouchStart() {
-    this._touchStarted = true;
-  }
-
-  onTouchMove() {
-    this._touchStarted = false;
-  }
-
-  // handle Tap event to dismiss keyboard
-  onTouchEnd() {
-    if (this._touchStarted === true) {
-      dismissKeyboard();
-    }
-    this._touchStarted = false;
   }
 
   renderMessages() {

--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -140,7 +140,6 @@ export default class MessageContainer extends React.Component {
       <View ref='container' style={{flex:1}}>
         <ListView
           enableEmptySections={true}
-          keyboardShouldPersistTaps={true}
           automaticallyAdjustContentInsets={false}
           initialListSize={20}
           pageSize={20}


### PR DESCRIPTION
I removed the dependency for `react-native-dismiss-keyboard` and removed the touch events. Instead of using touch events and dismiss manually the keyboard, we can remove `keyboardShouldPersistTaps` and it has the same effect.