### PR TITLE
Access to images in Library (FIXED crashes)

### DIFF
--- a/example/ios/GiftedChat/Info.plist
+++ b/example/ios/GiftedChat/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Access to your Gallery </string>
+	<key>NSCameraUsageDescription</key>
+	<string>Access to your Camera</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -39,7 +43,6 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSAppTransportSecurity</key>
-	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>


### PR DESCRIPTION
IOS - Example crashes when you want to choose an image via „choose from
library“ . Fixed that.  Example should work like intended.