### PR TITLE
Remove runAfterInteractions block on layout calculation

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -439,13 +439,11 @@ class GiftedChat extends React.Component {
         onLayout={(e) => {
           const layout = e.nativeEvent.layout;
           this.setMaxHeight(layout.height);
-          InteractionManager.runAfterInteractions(() => {
-            this.setState({
-              isInitialized: true,
-              text: '',
-              composerHeight: MIN_COMPOSER_HEIGHT,
-              messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight()),
-            });
+          this.setState({
+            isInitialized: true,
+            text: '',
+            composerHeight: MIN_COMPOSER_HEIGHT,
+            messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight()),
           });
         }}
       >


### PR DESCRIPTION
We were seeing the block in `runAfterInteractions` in `onLayout` never being called.
This would mean none of the chat UI would render.

Replicated this issue in react-native 0.36 and 0.38
It was only sporadic and seemed to happen more often on device.

I don't know too much about `runAfterInteractions`, is it guaranteed to be run?

Removing this block fixed our issue and didn't seem to break anything (our navigator animation is still smooth)