### PR TITLE
Add 'onPressActionButton' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ See [example/App.js](example/App.js)
 - **`renderComposer`** _(Function)_ - render the text input message composer
 - **`renderSend`** _(Function)_ - render the send button
 - **`renderAccessory`** _(Function)_ - renders a second line of actions below the message composer
+- **`onPressActionButton`** _(Function)_ - callback to perform custom logic when the Action button is pressed (the default `actionSheet` will not be used)
 - **`bottomOffset`** _(Integer)_ - distance of the chat from the bottom of the screen, useful if you display a tab bar
 
 

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -55,7 +55,7 @@ export default class Actions extends React.Component {
     return (
       <TouchableOpacity
         style={[styles.container, this.props.containerStyle]}
-        onPress={this.onActionsPress}
+        onPress={this.props.onPressActionButton || this.onActionsPress}
       >
         {this.renderIcon()}
       </TouchableOpacity>
@@ -103,6 +103,7 @@ Actions.propTypes = {
   options: React.PropTypes.object,
   optionTintColor: React.PropTypes.string,
   icon: React.PropTypes.func,
+  onPressActionButton: React.PropTypes.func,
   containerStyle: View.propTypes.style,
   iconTextStyle: Text.propTypes.style,
 };

--- a/src/InputToolbar.js
+++ b/src/InputToolbar.js
@@ -6,11 +6,14 @@ import {
 
 import Composer from './Composer';
 import Send from './Send';
+import Actions from './Actions';
 
 export default class InputToolbar extends React.Component {
   renderActions() {
     if (this.props.renderActions) {
       return this.props.renderActions(this.props);
+    } else if (this.props.onPressActionButton) {
+      return <Actions {...this.props} />;
     }
     return null;
   }
@@ -89,6 +92,7 @@ InputToolbar.propTypes = {
   renderActions: React.PropTypes.func,
   renderSend: React.PropTypes.func,
   renderComposer: React.PropTypes.func,
+  onPressActionButton: React.PropTypes.func,
   containerStyle: View.propTypes.style,
   primaryStyle: View.propTypes.style,
   accessoryStyle: View.propTypes.style,


### PR DESCRIPTION
Optional callback when the composer's Action button is pressed (the "+" icon). If this prop is provided, it will be used instead of the default method that shows an `actionSheet`. Therefore the action sheet won't be shown at all, and your function will be called instead.

This is nice if you have your own popup you want to use, for example [react-native-image-picker](https://github.com/marcshilling/react-native-image-picker).

Tested and verified on iOS and Android.