### PR TITLE
fix for npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@exponent/react-native-action-sheet": "0.3.0",
-    "md5": "2.1.1",
+    "md5": "2.2.1",
     "moment": "2.17.1",
     "react-native-communications": "2.1.1",
     "react-native-invertible-scroll-view": "1.0.0",


### PR DESCRIPTION
npm error during gifted-chat latest version install:

npm ERR! notarget No compatible version found: md5@2.1.1
npm ERR! notarget Valid install targets:
npm ERR! notarget 1.0.1, 1.0.0, 2.0.0, 2.1.0, 2.2.0, 2.2.1
