### PR TITLE
InteractionManager breaks sometimes, causes hard-to-debug issues

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -26,6 +26,7 @@ import MessageContainer from './MessageContainer';
 import Send from './Send';
 import Time from './Time';
 import GiftedAvatar from './GiftedAvatar';
+import GiftedChatInteractionManager from './GiftedChatInteractionManager';
 
 // Min and max heights of ToolbarInput and Composer
 // Needed for Composer auto grow and ScrollView animation
@@ -354,7 +355,7 @@ class GiftedChat extends React.Component {
       return;
     }
     this.setMaxHeight(layout.height);
-    InteractionManager.runAfterInteractions(() => {
+    GiftedChatInteractionManager.runAfterInteractions(() => {
       this.setState({
         isInitialized: true,
         text: '',

--- a/src/GiftedChatInteractionManager.js
+++ b/src/GiftedChatInteractionManager.js
@@ -1,0 +1,15 @@
+import { InteractionManager } from "react-native";
+export default {
+  ...InteractionManager,
+  runAfterInteractions:  f => {
+    // ensure f get called, timeout at 500ms
+    // @gre workaround https://github.com/facebook/react-native/issues/8624
+    let called = false;
+    const timeout = setTimeout(() => { called = true; f() }, 500);
+    InteractionManager.runAfterInteractions(() => {
+      if (called) return;
+      clearTimeout(timeout);
+      f();
+    });
+  }
+};


### PR DESCRIPTION
This pull request solves #350. Basically, when I was using react-native-navigation and calling a function called `resetTo` there, it simply broke the `InteractionManager` functionality, it was simply not calling the function you were passing as a parameter. More info about that [here](https://github.com/facebook/react-native/issues/8624).

Speaking about GiftedChat, I believe it's a serious problem and we should basically always display the chat. In my case, I had to debug the core of two big React Native libraries, so it would be good to merge this pull request.

A video about my bug: http://sendvid.com/qtsi7t1b
Solved now. Hope it helps you too.