### PR TITLE
Reset Input Toolbar can over calculate from bottomOffset props

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -321,7 +321,7 @@ class GiftedChat extends React.Component {
     this.setState({
       text: '',
       composerHeight: MIN_COMPOSER_HEIGHT,
-      messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight() - this.getKeyboardHeight() + this.props.bottomOffset),
+      messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMaxHeight() - this.getMinInputToolbarHeight() - this.getKeyboardHeight() + this.getBottomOffset()),
     });
   }
 


### PR DESCRIPTION
Ran into an issue in my implementation where I have a bottom offset for the input tool bar in the chat.  When a user inputs a message, dismisses the keyboard and then sends the message, the text input tool bar would end up being rendered too low and behind a few other view components.  Instead of using the this.props.bottomOffset, it should be using this.getBottomOffset() so that it doesn't incorrectly position when the keyboard is dismissed.  Verified that sending a message with the keyboard showing still works as intended.