### PR TITLE
Allow custom styling of buttom container of bubble

### DIFF
--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -129,7 +129,7 @@ export default class Bubble extends React.Component {
               {this.renderCustomView()}
               {this.renderMessageImage()}
               {this.renderMessageText()}
-              <View style={styles.bottom}>
+              <View style={[styles.bottom, this.props.bottomContainerStyle[this.props.position]]}>
                 {this.renderTime()}
                 {this.renderTicks()}
               </View>
@@ -240,6 +240,10 @@ Bubble.propTypes = {
     right: View.propTypes.style,
   }),
   wrapperStyle: React.PropTypes.shape({
+    left: View.propTypes.style,
+    right: View.propTypes.style,
+  }),
+  bottomContainerStyle: React.PropTypes.shape({
     left: View.propTypes.style,
     right: View.propTypes.style,
   }),


### PR DESCRIPTION
In the bubble, there is a container that holds both the time, and the ticks. This container did not provide customization options and forced both the ticks and the time to be rendered on the right (with `flex-end`).

I created another prop, `bottomContainerStyle` that allows to customize the style of the container :)