### PR TITLE
fix for _messageContainerRef === null

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -257,6 +257,7 @@ class GiftedChat extends React.Component {
   }
 
   scrollToBottom(animated = true) {
+    if (this._messageContainerRef === null) { return }
     this._messageContainerRef.scrollTo({
       y: 0,
       animated,


### PR DESCRIPTION
#### Issue Description

After asking for permissions for the camera or gallery, then selecting a photo I get the error "null is not an object (evaluating 'this._messageContainerRef.scrollTo')" This is caused by the _messageContainerRef not having been set, which crashes the app.

This line of code fixes the issue without any side effects.

#### Additional Information

* React Native version: 0.42.0
* react-native-gifted-chat version: 0.1.3
* Platform(s) (iOS, Android, or both?): iOS
