### PR TITLE
Bubble.js: Default value for prop bottomContainerStyle

### DIFF
--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -216,6 +216,7 @@ Bubble.defaultProps = {
   previousMessage: {},
   containerStyle: {},
   wrapperStyle: {},
+  bottomContainerStyle: {},
   tickStyle: {},
   containerToNextStyle: {},
   containerToPreviousStyle: {},


### PR DESCRIPTION
This solves the following issue: #407 

The reason of the bug was that there wasn't any default value for the newly introduced `bottomContainerStyle` property and therefore `this.props.bottomContainerStyle` is undefined if nothing is passed to the component, generating the mentioned exception when evaluating `this.props.bottomContainerStyle[this.props.position]`.