### PR TITLE
Bump react-native-communications version to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@expo/react-native-action-sheet": "0.3.0",
     "md5": "2.2.1",
     "moment": "2.17.1",
-    "react-native-communications": "2.1.1",
+    "react-native-communications": "2.2.1",
     "react-native-invertible-scroll-view": "1.0.0",
     "react-native-lightbox": "oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875",
     "react-native-parsed-text": "0.0.16",


### PR DESCRIPTION
Hey @kfiroo, I've been trying to get the Call and Text options to work on highlighted phone numbers in the message text. I needed to incorporate two fixes into my fork [this](https://github.com/anarchicknight/react-native-communications/issues/31) and another PR: https://github.com/FaridSafi/react-native-gifted-chat/pull/274

Let me know what you think, thanks!