### PR TITLE
Add maxLength parameter for Composer input

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See [example/App.js](example/App.js)
 - **`listViewProps`** _(Object)_ - extra props to be passed to the [`<ListView>`](https://facebook.github.io/react-native/docs/listview.html), some props can not be override, see the code in `render` method of `MessageContainer` for detail
 - **`keyboardShouldPersistTaps`** _(Enum)_ - determines when the keyboard should stay visible after a tap [`<ScrollView>`](https://facebook.github.io/react-native/docs/scrollview.html)
 - **`onInputTextChanged`** _(Function)_ - function that will be called when input text changes
+- **`maxInputLength`** _(Integer)_ - max Composer TextInput length
 
 ## Features
 - Custom components

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -412,7 +412,7 @@ class GiftedChat extends React.Component {
       textInputProps: {
         ...this.props.textInputProps,
         ref: textInput => this.textInput = textInput,
-        maxLength: this.getIsTypingDisabled() ? 0 : null
+        maxLength: this.getIsTypingDisabled() ? 0 : this.props.maxInputLength
       }
     };
     if (this.getIsTypingDisabled()) {
@@ -512,7 +512,8 @@ GiftedChat.defaultProps = {
   bottomOffset: 0,
   minInputToolbarHeight: 44,
   isLoadingEarlier: false,
-  messageIdGenerator: () => uuid.v4()
+  messageIdGenerator: () => uuid.v4(),
+  maxInputLength: null
 };
 
 GiftedChat.propTypes = {


### PR DESCRIPTION
Hi there!
I am working a React Native app that have chat feature.
This app have maximal chat text length specification (in my case is 400 chars).

So I have modify so user can set maxLength property to Composer's TextInput.