### PR TITLE
fix-extra spacing shown when avatar is not rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [example/App.js](example/App.js)
 - **`isLoadingEarlier`** _(Bool)_ - display an ActivityIndicator when loading earlier messages
 - **`renderLoading`** _(Function)_ - render a loading view when initializing
 - **`renderLoadEarlier`** _(Function)_ - render the load earlier button
-- **`renderAvatar`** _(Function)_ - renders the message avatar
+- **`renderAvatar`** _(Function)_ - renders the message avatar. Set to `null` to not render any avatar for the message
 - **`onPressAvatar`** _(Function(`user`))_ - callback when a message avatar is tapped
 - **`renderAvatarOnTop`** _(Bool)_ - render the message avatar, on top of consecutive messages. The default value is `false`.
 - **`renderBubble`** _(Function)_ - render the message bubble

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -23,6 +23,10 @@ export default class Avatar extends React.Component {
     const messageToCompare = renderAvatarOnTop ? this.props.previousMessage : this.props.nextMessage;
     const computedStyle = renderAvatarOnTop ? "onTop" : "onBottom"
 
+    if(this.props.shouldRenderAvatar === false) {
+      return null
+    }
+
     if (isSameUser(this.props.currentMessage, messageToCompare) && isSameDay(this.props.currentMessage, messageToCompare)) {
       return (
         <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
@@ -32,6 +36,7 @@ export default class Avatar extends React.Component {
         </View>
       );
     }
+    
     return (
       <View
         style={[styles[this.props.position].container, styles[this.props.position][computedStyle], this.props.containerStyle[this.props.position]]}>

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -23,7 +23,7 @@ export default class Avatar extends React.Component {
     const messageToCompare = renderAvatarOnTop ? this.props.previousMessage : this.props.nextMessage;
     const computedStyle = renderAvatarOnTop ? "onTop" : "onBottom"
 
-    if(this.props.shouldRenderAvatar === false) {
+    if (this.props.renderAvatar === null) {
       return null
     }
 


### PR DESCRIPTION
Related to issue #445 

I have added a new prop `shouldRenderAvatar` to control whether a user wants to render an avatar or not. I will document this property if the maintainers agree with the solution.