### PR TITLE
Allow user name to be shown for messages on the left side

### DIFF
--- a/src/GiftedAvatar.js
+++ b/src/GiftedAvatar.js
@@ -14,17 +14,7 @@ import {
 // handle only alpha numeric chars
 
 export default class GiftedAvatar extends React.Component {
-  setAvatarColor() {
-    const userName = this.props.user.name || '';
-    const name = userName.toUpperCase().split(' ');
-    if (name.length === 1) {
-      this.avatarName = `${name[0].charAt(0)}`;
-    } else if (name.length > 1) {
-      this.avatarName = `${name[0].charAt(0)}${name[1].charAt(0)}`;
-    } else {
-      this.avatarName = '';
-    }
-
+  static getColor(userName) {
     let sumChars = 0;
     for(let i = 0; i < userName.length; i++) {
       sumChars += userName.charCodeAt(i);
@@ -42,7 +32,18 @@ export default class GiftedAvatar extends React.Component {
       '#2c3e50', // midnight blue
     ];
 
-    this.avatarColor = colors[sumChars % colors.length];
+    return colors[sumChars % colors.length];
+  }
+
+  static getInitials(userName) {
+    const name = userName.toUpperCase().split(' ').filter(word => word !== '');
+    if (name.length === 1) {
+      return `${name[0].charAt(0)}`;
+    } else if (name.length > 1) {
+      return `${name[0].charAt(0)}${name[1].charAt(0)}`;
+    } else {
+      return '';
+    }
   }
 
   renderAvatar() {
@@ -69,7 +70,7 @@ export default class GiftedAvatar extends React.Component {
   renderInitials() {
     return (
       <Text style={[defaultStyles.textStyle, this.props.textStyle]}>
-        {this.avatarName}
+        {GiftedAvatar.getInitials(this.props.user.name)}
       </Text>
     );
   }
@@ -104,7 +105,7 @@ export default class GiftedAvatar extends React.Component {
     }
 
     if (!this.avatarColor) {
-      this.setAvatarColor();
+      this.avatarColor = GiftedAvatar.getColor(this.props.user.name || '')
     }
 
     return (

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -108,10 +108,9 @@ const styles = {
       textDecorationLine: 'underline',
     },
     usernameStyle: {
-      marginLeft: 2, 
-      marginRight: 2, 
-      marginTop: 2, 
-      marginBottom: 2, 
+      marginLeft: 5, 
+      marginTop: 5,
+      backgroundColor: 'transparent',
       lineHeight: 10, 
       fontSize: 10, 
       fontWeight: '700'

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -8,6 +8,8 @@ import {
 
 import ParsedText from 'react-native-parsed-text';
 import Communications from 'react-native-communications';
+import GiftedAvatar from './GiftedAvatar'
+import {isSameUser, isSameDay} from "./utils";
 
 export default class MessageText extends React.Component {
   constructor(props) {
@@ -48,9 +50,27 @@ export default class MessageText extends React.Component {
     Communications.email(email, null, null, null, null);
   }
 
+  renderUsername() {
+    if (this.props.renderUsername) {
+      const {renderUsername, ...usernameProps} = this.props;
+      return this.props.renderUsername(usernameProps);
+    }
+    return (
+      <Text style={[styles[this.props.position].usernameStyle,
+        {color: GiftedAvatar.getColor(this.props.currentMessage.user.name)},
+        this.props.usernameStyle]}>
+        {this.props.currentMessage.user.name}
+      </Text>
+    );
+  }
+
   render() {
     return (
       <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
+        {(!isSameUser(this.props.currentMessage, this.props.previousMessage) || !isSameDay(this.props.currentMessage, this.props.previousMessage)) && 
+          this.props.shouldRenderUsername && this.props.position === 'left' ? 
+          this.renderUsername() : null
+        }
         <ParsedText
           style={[styles[this.props.position].text, this.props.textStyle[this.props.position]]}
           parse={[
@@ -87,6 +107,15 @@ const styles = {
       color: 'black',
       textDecorationLine: 'underline',
     },
+    usernameStyle: {
+      marginLeft: 2, 
+      marginRight: 2, 
+      marginTop: 2, 
+      marginBottom: 2, 
+      lineHeight: 10, 
+      fontSize: 10, 
+      fontWeight: '700'
+    }
   }),
   right: StyleSheet.create({
     container: {
@@ -114,6 +143,7 @@ MessageText.defaultProps = {
   containerStyle: {},
   textStyle: {},
   linkStyle: {},
+  usernameStyle: {},
 };
 
 MessageText.propTypes = {

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -112,7 +112,7 @@ const styles = {
       marginRight: 5,
       marginTop: 5,
       backgroundColor: 'transparent',
-      lineHeight: 10, 
+      lineHeight: 12, 
       fontSize: 10, 
       fontWeight: '700'
     }

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -66,7 +66,7 @@ export default class MessageText extends React.Component {
 
   render() {
     return (
-      <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
+      <View style={[styles[this.props.position].container, this.props.messageTextContainerStyle[this.props.position]]}>
         {(!isSameUser(this.props.currentMessage, this.props.previousMessage) || !isSameDay(this.props.currentMessage, this.props.previousMessage))
           && (this.props.renderUsername !== null) && this.props.position === 'left' ? 
           this.renderUsername() : null

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -108,7 +108,8 @@ const styles = {
       textDecorationLine: 'underline',
     },
     usernameStyle: {
-      marginLeft: 5, 
+      marginLeft: 5,
+      marginRight: 5,
       marginTop: 5,
       backgroundColor: 'transparent',
       lineHeight: 10, 

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -67,8 +67,8 @@ export default class MessageText extends React.Component {
   render() {
     return (
       <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
-        {(!isSameUser(this.props.currentMessage, this.props.previousMessage) || !isSameDay(this.props.currentMessage, this.props.previousMessage)) && 
-          this.props.shouldRenderUsername && this.props.position === 'left' ? 
+        {(!isSameUser(this.props.currentMessage, this.props.previousMessage) || !isSameDay(this.props.currentMessage, this.props.previousMessage))
+          && (this.props.renderUsername !== null) && this.props.position === 'left' ? 
           this.renderUsername() : null
         }
         <ParsedText

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -66,7 +66,7 @@ export default class MessageText extends React.Component {
 
   render() {
     return (
-      <View style={[styles[this.props.position].container, this.props.messageTextContainerStyle[this.props.position]]}>
+      <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
         {(!isSameUser(this.props.currentMessage, this.props.previousMessage) || !isSameDay(this.props.currentMessage, this.props.previousMessage))
           && (this.props.renderUsername !== null) && this.props.position === 'left' ? 
           this.renderUsername() : null


### PR DESCRIPTION
Sometimes just the avatar is not enough to figure out who sent the messages on the left side. Also, the user may not want to render the user avatar on the left also in which case it is even more important to be able to show the person name who sent the messages. Added two new props `shouldRenderUsername` and `renderUsername` to control showing user names for messages.