### PR TITLE
Fix wrong styling props used for some components

### DIFF
--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -79,7 +79,7 @@ Avatar.defaultProps = {
     user: null,
   },
   nextMessage: {},
-  containerStyle: {},
+  avatarContainerStyle: {},
   imageStyle: {},
   //TODO: remove in next major release
   isSameDay: warnDeprecated(isSameDay),
@@ -92,7 +92,7 @@ Avatar.propTypes = {
   currentMessage: React.PropTypes.object,
   nextMessage: React.PropTypes.object,
   onPressAvatar: React.PropTypes.func,
-  containerStyle: React.PropTypes.shape({
+  avatarContainerStyle: React.PropTypes.shape({
     left: View.propTypes.style,
     right: View.propTypes.style,
   }),

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -25,7 +25,7 @@ export default class Avatar extends React.Component {
 
     if (isSameUser(this.props.currentMessage, messageToCompare) && isSameDay(this.props.currentMessage, messageToCompare)) {
       return (
-        <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
+        <View style={[styles[this.props.position].container, this.props.avatarContainerStyle[this.props.position]]}>
           <GiftedAvatar
             avatarStyle={StyleSheet.flatten([styles[this.props.position].image, this.props.imageStyle[this.props.position]])}
           />
@@ -34,7 +34,7 @@ export default class Avatar extends React.Component {
     }
     return (
       <View
-        style={[styles[this.props.position].container, styles[this.props.position][computedStyle], this.props.containerStyle[this.props.position]]}>
+        style={[styles[this.props.position].container, styles[this.props.position][computedStyle], this.props.avatarContainerStyle[this.props.position]]}>
         {this.renderAvatar()}
       </View>
     );

--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -35,7 +35,7 @@ export default class Bubble extends React.Component {
 
   renderMessageText() {
     if (this.props.currentMessage.text) {
-      const {containerStyle, wrapperStyle, ...messageTextProps} = this.props;
+      const {wrapperStyle, ...messageTextProps} = this.props;
       if (this.props.renderMessageText) {
         return this.props.renderMessageText(messageTextProps);
       }
@@ -46,7 +46,7 @@ export default class Bubble extends React.Component {
 
   renderMessageImage() {
     if (this.props.currentMessage.image) {
-      const {containerStyle, wrapperStyle, ...messageImageProps} = this.props;
+      const {wrapperStyle, ...messageImageProps} = this.props;
       if (this.props.renderMessageImage) {
         return this.props.renderMessageImage(messageImageProps);
       }
@@ -75,7 +75,7 @@ export default class Bubble extends React.Component {
 
   renderTime() {
     if (this.props.currentMessage.createdAt) {
-      const {containerStyle, wrapperStyle, ...timeProps} = this.props;
+      const {wrapperStyle, ...timeProps} = this.props;
       if (this.props.renderTime) {
         return this.props.renderTime(timeProps);
       }
@@ -214,7 +214,7 @@ Bubble.defaultProps = {
   },
   nextMessage: {},
   previousMessage: {},
-  containerStyle: {},
+  bubbleContainerStyle: {},
   wrapperStyle: {},
   bottomContainerStyle: {},
   tickStyle: {},
@@ -236,7 +236,7 @@ Bubble.propTypes = {
   currentMessage: React.PropTypes.object,
   nextMessage: React.PropTypes.object,
   previousMessage: React.PropTypes.object,
-  containerStyle: React.PropTypes.shape({
+  bubbleContainerStyle: React.PropTypes.shape({
     left: View.propTypes.style,
     right: View.propTypes.style,
   }),

--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -118,7 +118,7 @@ export default class Bubble extends React.Component {
 
   render() {
     return (
-      <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
+      <View style={[styles[this.props.position].container, this.props.bubbleContainerStyle[this.props.position]]}>
         <View style={[styles[this.props.position].wrapper, this.props.wrapperStyle[this.props.position], this.handleBubbleToNext(), this.handleBubbleToPrevious()]}>
           <TouchableWithoutFeedback
             onLongPress={this.onLongPress}

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -12,7 +12,7 @@ export default class MessageImage extends React.Component {
     const { width, height } = Dimensions.get('window');
 
     return (
-      <View style={[styles.container, this.props.containerStyle]}>
+      <View style={[styles.container, this.props.messageImageContainerStyle]}>
         <Lightbox
           activeProps={{
             style: [styles.imageActive, { width, height }],

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -49,7 +49,7 @@ MessageImage.defaultProps = {
   currentMessage: {
     image: null,
   },
-  containerStyle: {},
+  messageImageContainerStyle: {},
   imageStyle: {},
   imageProps: {},
   lightboxProps: {},
@@ -57,7 +57,7 @@ MessageImage.defaultProps = {
 
 MessageImage.propTypes = {
   currentMessage: React.PropTypes.object,
-  containerStyle: View.propTypes.style,
+  messageImageContainerStyle: View.propTypes.style,
   imageStyle: Image.propTypes.style,
   imageProps: React.PropTypes.object,
   lightboxProps: React.PropTypes.object,

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -111,7 +111,7 @@ MessageText.defaultProps = {
   currentMessage: {
     text: '',
   },
-  containerStyle: {},
+  messageTextContainerStyle: {},
   textStyle: {},
   linkStyle: {},
 };
@@ -119,7 +119,7 @@ MessageText.defaultProps = {
 MessageText.propTypes = {
   position: React.PropTypes.oneOf(['left', 'right']),
   currentMessage: React.PropTypes.object,
-  containerStyle: React.PropTypes.shape({
+  messageTextContainerStyle: React.PropTypes.shape({
     left: View.propTypes.style,
     right: View.propTypes.style,
   }),

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -50,7 +50,7 @@ export default class MessageText extends React.Component {
 
   render() {
     return (
-      <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
+      <View style={[styles[this.props.position].container, this.props.messageTextContainerStyle[this.props.position]]}>
         <ParsedText
           style={[styles[this.props.position].text, this.props.textStyle[this.props.position]]}
           parse={[

--- a/src/Time.js
+++ b/src/Time.js
@@ -10,7 +10,7 @@ import moment from 'moment/min/moment-with-locales.min';
 export default class Time extends React.Component {
   render() {
     return (
-      <View style={[styles[this.props.position].container, this.props.containerStyle[this.props.position]]}>
+      <View style={[styles[this.props.position].container, this.props.timeContainerStyle[this.props.position]]}>
         <Text style={[styles[this.props.position].text, this.props.textStyle[this.props.position]]}>
           {moment(this.props.currentMessage.createdAt).locale(this.context.getLocale()).format('LT')}
         </Text>

--- a/src/Time.js
+++ b/src/Time.js
@@ -11,7 +11,7 @@ export default class Time extends React.Component {
   render() {
     return (
       <View style={[styles[this.props.position].container, this.props.timeContainerStyle[this.props.position]]}>
-        <Text style={[styles[this.props.position].text, this.props.textStyle[this.props.position]]}>
+        <Text style={[styles[this.props.position].text, this.props.timeTextStyle[this.props.position]]}>
           {moment(this.props.currentMessage.createdAt).locale(this.context.getLocale()).format('LT')}
         </Text>
       </View>
@@ -62,7 +62,7 @@ Time.defaultProps = {
     createdAt: null,
   },
   timeContainerStyle: {},
-  textStyle: {},
+  timeTextStyle: {},
 };
 
 Time.propTypes = {
@@ -72,7 +72,7 @@ Time.propTypes = {
     left: View.propTypes.style,
     right: View.propTypes.style,
   }),
-  textStyle: React.PropTypes.shape({
+  timeTextStyle: React.PropTypes.shape({
     left: Text.propTypes.style,
     right: Text.propTypes.style,
   }),

--- a/src/Time.js
+++ b/src/Time.js
@@ -61,14 +61,14 @@ Time.defaultProps = {
   currentMessage: {
     createdAt: null,
   },
-  containerStyle: {},
+  timeContainerStyle: {},
   textStyle: {},
 };
 
 Time.propTypes = {
   position: React.PropTypes.oneOf(['left', 'right']),
   currentMessage: React.PropTypes.object,
-  containerStyle: React.PropTypes.shape({
+  timeContainerStyle: React.PropTypes.shape({
     left: View.propTypes.style,
     right: View.propTypes.style,
   }),


### PR DESCRIPTION
Some of the internal components are using `containerStyle` styling prop to allow the user to change the way those components from within their app but the `containerStyle` prop is filtered out when the `Bubble` is rendered. It is done in `Message.js` in the `getInnerComponentProps` method

```javascript
  getInnerComponentProps() {
    const {containerStyle, ...props} = this.props;
    return {
      ...props,
      isSameUser,
      isSameDay
    }
  }
```

Due to this, `containerStyle` prop is never transferred to components such as `Avatar`, `Time` which are using `containerStyle` to change their styling.

I have renamed the `containerStyle` prop in such components such that their styling is configurable from within the app.

I have also renamed the `textStyle` prop name to `timeTextStyle` which could be a breaking change but I couldn't understand under what circumstances would I want to use same styles for message text and time. I would be happy to merge it with `textStyle` to make it backward compatible if maintainers think that is a better solution. I feel that if I do merge them together, then I would have to explicitly cancel out some styles defined in `textStyle` if I don't want to use them for time text.

If I have misunderstood the code, please let me know.