### PR TITLE
fix isSameDay function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,12 +4,16 @@ const DEPRECATION_MESSAGE = 'isSameUser and isSameDay should be imported from th
 
 export function isSameDay(currentMessage = {}, diffMessage = {}) {
 
-  if(!diffMessage.createdAt) {
+  if (!diffMessage.createdAt) {
     return false
   }
 
   let currentCreatedAt = moment(currentMessage.createdAt);
   let diffCreatedAt = moment(diffMessage.createdAt);
+
+  if (!currentCreatedAt.isValid() || !diffCreatedAt.isValid()) {
+    return false;
+  }
 
   return currentCreatedAt.isSame(diffCreatedAt, 'day');
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,12 +4,12 @@ const DEPRECATION_MESSAGE = 'isSameUser and isSameDay should be imported from th
 
 export function isSameDay(currentMessage = {}, diffMessage = {}) {
 
+  if(!diffMessage.createdAt) {
+    return false
+  }
+
   let currentCreatedAt = moment(currentMessage.createdAt);
   let diffCreatedAt = moment(diffMessage.createdAt);
-
-  if (!currentCreatedAt.isValid() || !diffCreatedAt.isValid()) {
-    return false;
-  }
 
   return currentCreatedAt.isSame(diffCreatedAt, 'day');
 


### PR DESCRIPTION
`isSameDay` method was returning `true` if we feed a `currentMessage` which is created today and an empty `diffMessage`. That is because `moment(undefined)` call will initialize the moment object to today's date. I think we were using `isValid` to make sure that there is a valid `createdAt` for `currentMessage` and `diffMessage` but `moment(undefined).isValid()` will return true.

I have changed the method to make sure that we have a valid `createdAt` date for `diffMessage` and remove the `isValid()` calls as they will always return true.