### PR TITLE
Added method to add message templates to composer. 

### DIFF
--- a/src/Composer.js
+++ b/src/Composer.js
@@ -28,7 +28,7 @@ export default class Composer extends React.Component {
         placeholderTextColor={this.props.placeholderTextColor}
         multiline={this.props.multiline}
 
-        onChange={(e) => this.onChange(e)}
+        onContentSizeChange={(e) => this.onChange(e)}
         onChangeText={text => this.onChangeText(text)}
 
         style={[styles.textInput, this.props.textInputStyle, {height: this.props.composerHeight}]}

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -93,6 +93,12 @@ class GiftedChat extends React.Component {
     return currentMessages.concat(messages);
   }
 
+  setComposerText(text) {
+    this.setState({
+        text: text
+    })
+  }
+
   getChildContext() {
     return {
       actionSheet: () => this._actionSheetRef,


### PR DESCRIPTION
Required change to composer so content size change was accurately reflected back to GiftedChat component.

Usage is

```js
<GiftedChat
  ref={(ref) => this.chat = ref}
 ...props
>
</GiftedChat>

someEventHappened = (text) => {
  this.chat.setComposerText(text);
}
```