### PR TITLE
flex instead of full width/height for images.

### DIFF
--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -15,7 +15,7 @@ export default class MessageImage extends React.Component {
       <View style={[styles.container, this.props.containerStyle]}>
         <Lightbox
           activeProps={{
-            style: [styles.imageActive, { width, height }],
+            style: styles.imageActive,
           }}
           {...this.props.lightboxProps}
         >
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
     resizeMode: 'cover',
   },
   imageActive: {
+    flex: 1,
     resizeMode: 'contain',
   },
 });


### PR DESCRIPTION
Setting image to full width/height makes animation returning image to previous spot look extremely awkward. flex: 1 allows image to resize between thumbnail and fullscreen as was intended with lightbox.