### PR TITLE
Fix default rendering of avatars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules/
 npm-debug.log
 TODO.md
+
+.idea

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -493,7 +493,7 @@ GiftedChat.defaultProps = {
   }),
   renderAccessory: null,
   renderActions: null,
-  renderAvatar: null,
+  renderAvatar: undefined,
   renderBubble: null,
   renderFooter: null,
   renderChatFooter: null,

--- a/src/Message.js
+++ b/src/Message.js
@@ -86,7 +86,7 @@ const styles = {
 };
 
 Message.defaultProps = {
-  renderAvatar: null,
+  renderAvatar: undefined,
   renderBubble: null,
   renderDay: null,
   position: 'left',


### PR DESCRIPTION
Simple fix: default `renderAvatar` to `undefined` instead of `null`, now that `null` causes it to not be rendered at all.

Originally mentioned in https://github.com/FaridSafi/react-native-gifted-chat/pull/447#issuecomment-305815371; see there for more context.