### PR TITLE
Add children props to Send component

### DIFF
--- a/src/Send.js
+++ b/src/Send.js
@@ -23,7 +23,15 @@ export default class Send extends React.Component {
           }}
           accessibilityTraits="button"
         >
-          <Text style={[styles.text, this.props.textStyle]}>{this.props.label}</Text>
+            {this.props.children ?
+              <View>
+                {this.props.children}
+              </View>
+              :
+              <View>
+                <Text style={[styles.text, this.props.textStyle]}>{this.props.label}</Text>
+              </View>
+            }
         </TouchableOpacity>
       );
     }


### PR DESCRIPTION
With this fix, you can set an image as a sender button or anything you want to.

```
renderSend(props) {
        return (
            <Send
                {...props}
            >
                <View style={{marginRight: 10, marginBottom: 5}}>
                    <Image source={require('../../assets/send.png')} resizeMode={'center'}/>
                </View>
            </Send>
        );
    }
```