### PR TITLE
Replace View.propTypes with ViewPropTypes

### DIFF
--- a/example/CustomActions.js
+++ b/example/CustomActions.js
@@ -5,6 +5,7 @@ import {
   TouchableOpacity,
   View,
   Text,
+  ViewPropTypes,
 } from 'react-native';
 
 import CameraRollPicker from 'react-native-camera-roll-picker';
@@ -197,7 +198,7 @@ CustomActions.propTypes = {
   onSend: React.PropTypes.func,
   options: React.PropTypes.object,
   icon: React.PropTypes.func,
-  containerStyle: View.propTypes.style,
-  wrapperStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
+  wrapperStyle: ViewPropTypes.style,
   iconTextStyle: Text.propTypes.style,
 };

--- a/example/CustomView.js
+++ b/example/CustomView.js
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 export default class CustomView extends React.Component {
@@ -62,8 +63,8 @@ CustomView.defaultProps = {
   mapViewStyle: {},
 };
 
-CustomView.propTypes = {
+CustomViewPropTypes = {
   currentMessage: React.PropTypes.object,
-  containerStyle: View.propTypes.style,
-  mapViewStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
+  mapViewStyle: ViewPropTypes.style,
 };

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -4,6 +4,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 export default class Actions extends React.Component {
@@ -104,6 +105,6 @@ Actions.propTypes = {
   optionTintColor: React.PropTypes.string,
   icon: React.PropTypes.func,
   onPressActionButton: React.PropTypes.func,
-  containerStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
   iconTextStyle: Text.propTypes.style,
 };

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {Image, StyleSheet, View} from "react-native";
+import {Image, StyleSheet, View, ViewPropTypes} from "react-native";
 import GiftedAvatar from "./GiftedAvatar";
 import {isSameUser, isSameDay, warnDeprecated} from "./utils";
 
@@ -98,12 +98,12 @@ Avatar.propTypes = {
   nextMessage: React.PropTypes.object,
   onPressAvatar: React.PropTypes.func,
   containerStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   imageStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   //TODO: remove in next major release
   isSameDay: React.PropTypes.func,

--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import MessageText from './MessageText';
@@ -237,25 +238,25 @@ Bubble.propTypes = {
   nextMessage: React.PropTypes.object,
   previousMessage: React.PropTypes.object,
   containerStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   wrapperStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   bottomContainerStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   tickStyle: Text.propTypes.style,
   containerToNextStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   containerToPreviousStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   //TODO: remove in next major release
   isSameDay: React.PropTypes.func,

--- a/src/Day.js
+++ b/src/Day.js
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   Text,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import moment from 'moment/min/moment-with-locales.min';
@@ -70,8 +71,8 @@ Day.defaultProps = {
 Day.propTypes = {
   currentMessage: React.PropTypes.object,
   previousMessage: React.PropTypes.object,
-  containerStyle: View.propTypes.style,
-  wrapperStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
+  wrapperStyle: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
   //TODO: remove in next major release
   isSameDay: React.PropTypes.func,

--- a/src/InputToolbar.js
+++ b/src/InputToolbar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   StyleSheet,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import Composer from './Composer';
@@ -93,7 +94,7 @@ InputToolbar.propTypes = {
   renderSend: React.PropTypes.func,
   renderComposer: React.PropTypes.func,
   onPressActionButton: React.PropTypes.func,
-  containerStyle: View.propTypes.style,
-  primaryStyle: View.propTypes.style,
-  accessoryStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
+  primaryStyle: ViewPropTypes.style,
+  accessoryStyle: ViewPropTypes.style,
 };

--- a/src/LoadEarlier.js
+++ b/src/LoadEarlier.js
@@ -6,6 +6,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 export default class LoadEarlier extends React.Component {
@@ -94,8 +95,8 @@ LoadEarlier.propTypes = {
   onLoadEarlier: React.PropTypes.func,
   isLoadingEarlier: React.PropTypes.bool,
   label: React.PropTypes.string,
-  containerStyle: View.propTypes.style,
-  wrapperStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
+  wrapperStyle: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
-  activityIndicatorStyle: View.propTypes.style,
+  activityIndicatorStyle: ViewPropTypes.style,
 };

--- a/src/Message.js
+++ b/src/Message.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   View,
   StyleSheet,
+  ViewPropTypes,
 } from 'react-native';
 
 import Avatar from './Avatar';
@@ -107,7 +108,7 @@ Message.propTypes = {
   previousMessage: React.PropTypes.object,
   user: React.PropTypes.object,
   containerStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
 };

--- a/src/MessageImage.js
+++ b/src/MessageImage.js
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   View,
   Dimensions,
+  ViewPropTypes,
 } from 'react-native';
 import Lightbox from 'react-native-lightbox';
 
@@ -57,7 +58,7 @@ MessageImage.defaultProps = {
 
 MessageImage.propTypes = {
   currentMessage: React.PropTypes.object,
-  containerStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
   imageStyle: Image.propTypes.style,
   imageProps: React.PropTypes.object,
   lightboxProps: React.PropTypes.object,

--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   Text,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import ParsedText from 'react-native-parsed-text';
@@ -120,8 +121,8 @@ MessageText.propTypes = {
   position: React.PropTypes.oneOf(['left', 'right']),
   currentMessage: React.PropTypes.object,
   containerStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   textStyle: React.PropTypes.shape({
     left: Text.propTypes.style,

--- a/src/Send.js
+++ b/src/Send.js
@@ -4,6 +4,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 export default class Send extends React.Component {
@@ -59,6 +60,6 @@ Send.propTypes = {
   text: React.PropTypes.string,
   onSend: React.PropTypes.func,
   label: React.PropTypes.string,
-  containerStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
 };

--- a/src/Time.js
+++ b/src/Time.js
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   Text,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import moment from 'moment/min/moment-with-locales.min';
@@ -69,8 +70,8 @@ Time.propTypes = {
   position: React.PropTypes.oneOf(['left', 'right']),
   currentMessage: React.PropTypes.object,
   containerStyle: React.PropTypes.shape({
-    left: View.propTypes.style,
-    right: View.propTypes.style,
+    left: ViewPropTypes.style,
+    right: ViewPropTypes.style,
   }),
   textStyle: React.PropTypes.shape({
     left: Text.propTypes.style,


### PR DESCRIPTION
Fix for React Native’s Warning: “View.propTypes has been deprecated and will be removed in a future version of ReactNative. Use ViewPropTypes instead”