### PR TITLE
Start messages at top

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -83,7 +83,7 @@ class GiftedChat extends React.Component {
     if (!Array.isArray(messages)) {
       messages = [messages];
     }
-    return messages.concat(currentMessages);
+    return currentMessages.concat(messages);
   }
 
   static prepend(currentMessages = [], messages) {

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -70,7 +70,7 @@ class GiftedChat extends React.Component {
 
 
     this.invertibleScrollViewProps = {
-      inverted: true,
+      inverted: false,
       keyboardShouldPersistTaps: this.props.keyboardShouldPersistTaps,
       onKeyboardWillShow: this.onKeyboardWillShow,
       onKeyboardWillHide: this.onKeyboardWillHide,


### PR DESCRIPTION
This is a simple fix. It just turns off the inverted prop of the inverted scroll view and has new messages appended to current messages rather than the other way around.