### PR TITLE
Take into account the keyboard height in onLayout

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -390,7 +390,7 @@ class GiftedChat extends React.Component {
     if (this.getMaxHeight() !== layout.height || this.getIsFirstLayout() === true) {
       this.setMaxHeight(layout.height);
       this.setState({
-        messagesContainerHeight: this.prepareMessagesContainerHeight(this.getBasicMessagesContainerHeight()),
+        messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMessagesContainerHeightWithKeyboard()),
       });
     }
     if (this.getIsFirstLayout() === true) {


### PR DESCRIPTION
Without this dynamic layout changes occuring while keyboard is on can result
in pushing the input field behind the keyboard and making it invisible.