### PR TITLE
Fix URLs that are missing a scheme before attempting to open

### DIFF
--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -10,6 +10,8 @@ import {
 import ParsedText from 'react-native-parsed-text';
 import Communications from 'react-native-communications';
 
+const WWW_URL_PATTERN = /^www\./i;
+
 export default class MessageText extends React.Component {
   constructor(props) {
     super(props);
@@ -19,7 +21,11 @@ export default class MessageText extends React.Component {
   }
 
   onUrlPress(url) {
-    Linking.openURL(url);
+    if (url.match(WWW_URL_PATTERN)) {
+      this.onUrlPress('http://' + url);
+    } else if (Linking.canOpenURL(url)) {
+      Linking.openURL(url);
+    }
   }
 
   onPhonePress(phone) {


### PR DESCRIPTION
When someone sends a message that includes a website address beginning with "www." (omitting the scheme), `react-native-parsed-text` [recognizes it as a valid url](https://github.com/taskrabbit/react-native-parsed-text/blob/v0.0.18/src/ParsedText.js#L7), and this appears to be the intended behavior of `react-native-parsed-text`.

This is currently causing an error in `react-native-gifted-chat` because we're trying to open it directly with `Linking.openURL`, and as the react-native [Linking](https://facebook.github.io/react-native/docs/linking.html) docs indicate:
> For web URLs, the protocol ("http://", "https://") must be set accordingly

This attempts to fix the issue by inferring "http://" when no scheme is present in the URL.

Since the regex pattern used by `react-native-parsed-text` has the potential to recognize other strings as valid URLs (which may not in fact be valid), it's probably a good idea to also check the URL with `Linking.canOpenURL` before attempting to open it.