### PR TITLE
Add 'showUserAvatar' prop; don't render null avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ e.g.
 - **`renderLoading`** _(Function)_ - Render a loading view when initializing
 - **`renderLoadEarlier`** _(Function)_ - Custom "Load earlier messages" button
 - **`renderAvatar`** _(Function)_ - Custom message avatar; set to `null` to not render any avatar for the message
+- **`showUserAvatar`** _(Function)_ - Whether to render an avatar for the current user; default is `false`, only show avatars for other users
 - **`onPressAvatar`** _(Function(`user`))_ - Callback when a message avatar is tapped
 - **`renderAvatarOnTop`** _(Bool)_ - Render the message avatar at the top of consecutive messages, rather than the bottom (default)
 - **`renderBubble`** _(Function)_ - Custom message bubble

--- a/src/Message.js
+++ b/src/Message.js
@@ -43,11 +43,12 @@ export default class Message extends React.Component {
   }
 
   renderAvatar() {
-    if (this.props.user._id !== this.props.currentMessage.user._id) {
-      const avatarProps = this.getInnerComponentProps();
-      return <Avatar {...avatarProps}/>;
+    const avatarProps = this.getInnerComponentProps();
+    const { currentMessage } = avatarProps;
+    if(typeof currentMessage.user.avatar === 'undefined') {
+      return null;
     }
-    return null;
+    return <Avatar {...avatarProps}/>;
   }
 
   render() {

--- a/src/Message.js
+++ b/src/Message.js
@@ -43,6 +43,9 @@ export default class Message extends React.Component {
   }
 
   renderAvatar() {
+    if (this.props.user._id === this.props.currentMessage.user._id && !this.props.showUserAvatar) {
+      return null;
+    }
     const avatarProps = this.getInnerComponentProps();
     const { currentMessage } = avatarProps;
     if (currentMessage.user.avatar === null) {
@@ -90,6 +93,7 @@ const styles = {
 
 Message.defaultProps = {
   renderAvatar: undefined,
+  showUserAvatar: false,
   renderBubble: null,
   renderDay: null,
   position: 'left',
@@ -102,6 +106,7 @@ Message.defaultProps = {
 
 Message.propTypes = {
   renderAvatar: PropTypes.func,
+  showUserAvatar: PropTypes.bool,
   renderBubble: PropTypes.func,
   renderDay: PropTypes.func,
   position: PropTypes.oneOf(['left', 'right']),

--- a/src/Message.js
+++ b/src/Message.js
@@ -45,10 +45,10 @@ export default class Message extends React.Component {
   renderAvatar() {
     const avatarProps = this.getInnerComponentProps();
     const { currentMessage } = avatarProps;
-    if(typeof currentMessage.user.avatar === 'undefined') {
+    if (currentMessage.user.avatar === null) {
       return null;
     }
-    return <Avatar {...avatarProps}/>;
+    return <Avatar {...avatarProps} />;
   }
 
   render() {


### PR DESCRIPTION
- check if current message user has an avatar to display
- don't base the logic of the display of the avatar on the user object id

Issue: #495
Issue URL: https://github.com/FaridSafi/react-native-gifted-chat/issues/495

Screenshot with the behaviour before:
<img width="375" alt="screen shot 2017-07-21 at 14 48 27" src="https://user-images.githubusercontent.com/1969742/28463370-b96e2be6-6e28-11e7-99e2-c6e7b6e7cac6.png">

Screenshot with the behaviour after:
<img width="368" alt="screen shot 2017-07-21 at 14 50 00" src="https://user-images.githubusercontent.com/1969742/28463374-bef13c7a-6e28-11e7-9a3a-07f376e8ed2d.png">