### PR TITLE
Fix Linking.canOpenURL usage

### DIFF
--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -26,10 +26,14 @@ export default class MessageText extends React.Component {
     // react-native-parsed-text recognizes it as a valid url, but Linking fails to open due to the missing scheme.
     if (WWW_URL_PATTERN.test(url)) {
       this.onUrlPress(`http://${url}`);
-    } else if (Linking.canOpenURL(url)) {
-      Linking.openURL(url);
     } else {
-      console.error('No handler for URL:', url);
+      Linking.canOpenURL(url).then((supported) => {
+        if (!supported) {
+          console.error('No handler for URL:', url);
+        } else {
+          Linking.openURL(url);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
This fixes an error in my [previous PR](https://github.com/FaridSafi/react-native-gifted-chat/pull/506) which included a check for openable URLs. `Linking.canOpenURL` returns a promise, so we need to call it accordingly.