### PR TITLE
fixed phonePress actions order

### DIFF
--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -35,8 +35,8 @@ export default class MessageText extends React.Component {
 
   onPhonePress(phone) {
     const options = [
-      'Text',
       'Call',
+      'Text',
       'Cancel',
     ];
     const cancelButtonIndex = options.length - 1;


### PR DESCRIPTION
When pressing on Text, it started a call, and when pressing on call, it open the messaging app.
I just fixed the order in the options array