### PR TITLE
Fixed email recipient when clicking an email link

### DIFF
--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -57,7 +57,7 @@ export default class MessageText extends React.Component {
   }
 
   onEmailPress(email) {
-    Communications.email(email, null, null, null, null);
+    Communications.email([email], null, null, null, null);
   }
 
   render() {


### PR DESCRIPTION
[react-native-communications](https://github.com/anarchicknight/react-native-communications) take as first argument for Communications.email a string array and not a string. I fixed this.

