### PR TITLE
Updated dependencies for compatibility with React 16 and RN > 0.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "moment": "2.18.1",
     "prop-types": "15.5.10",
     "react-native-communications": "2.2.1",
-    "react-native-invertible-scroll-view": "1.0.0",
+    "react-native-invertible-scroll-view": "git+https://github.com/brunocascio/react-native-invertible-scroll-view.git",
     "react-native-lightbox": "git+https://github.com/brunocascio/react-native-lightbox.git",
-    "react-native-parsed-text": "git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064",
+    "react-native-parsed-text": "git+https://github.com/brunocascio/react-native-parsed-text.git",
     "shallowequal": "1.0.2",
     "uuid": "3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
     "eslint-plugin-react-native": "2.3.2"
   },
   "dependencies": {
-    "@expo/react-native-action-sheet": "cribspot/react-native-action-sheet#b422c54f26d30b9e85eb14a882ea9cec38600730",
+    "@expo/react-native-action-sheet": "^1.0.1",
     "md5": "2.2.1",
-    "moment": "2.19.0",
+    "moment": "^2.19.0",
     "prop-types": "15.5.10",
     "react-native-communications": "2.2.1",
-    "react-native-invertible-scroll-view": "git+https://github.com/brunocascio/react-native-invertible-scroll-view.git",
-    "react-native-lightbox": "git+https://github.com/brunocascio/react-native-lightbox.git",
-    "react-native-parsed-text": "git+https://github.com/brunocascio/react-native-parsed-text.git",
+    "react-native-invertible-scroll-view": "^1.1.0",
+    "react-native-lightbox": "^0.7.0",
+    "react-native-parsed-text": "^0.0.19",
     "shallowequal": "1.0.2",
     "uuid": "3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prop-types": "15.5.10",
     "react-native-communications": "2.2.1",
     "react-native-invertible-scroll-view": "1.0.0",
-    "react-native-lightbox": "oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875",
+    "react-native-lightbox": "git+https://github.com/brunocascio/react-native-lightbox.git",
     "react-native-parsed-text": "git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064",
     "shallowequal": "1.0.2",
     "uuid": "3.1.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-native-communications": "2.2.1",
     "react-native-invertible-scroll-view": "1.0.0",
     "react-native-lightbox": "oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875",
-    "react-native-parsed-text": "0.0.18",
+    "react-native-parsed-text": "git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064",
     "shallowequal": "1.0.2",
     "uuid": "3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gifted-chat",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The most complete chat UI for React Native",
   "main": "index.js",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,11 @@
 # yarn lockfile v1
 
 
-"@expo/react-native-action-sheet@cribspot/react-native-action-sheet#b422c54f26d30b9e85eb14a882ea9cec38600730":
-  version "1.0.0"
-  resolved "https://codeload.github.com/cribspot/react-native-action-sheet/tar.gz/b422c54f26d30b9e85eb14a882ea9cec38600730"
+"@expo/react-native-action-sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-1.0.1.tgz#c02f36688a1e4f8dc60890ff3c734944af541c6b"
   dependencies:
-    hoist-non-react-statics "^1.2.0"
+    hoist-non-react-statics "^2.2.2"
     prop-types "^15.5.10"
 
 acorn-jsx@^3.0.0:
@@ -625,9 +625,9 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 hosted-git-info@^2.1.4:
   version "2.5.0"
@@ -860,9 +860,9 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.0.tgz#44f675ef6b944942762581b1c179fb679e599d67"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1030,36 +1030,30 @@ react-native-communications@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-native-communications/-/react-native-communications-2.2.1.tgz#7883b56b20a002eeb790c113f8616ea8692ca795"
 
-"react-native-invertible-scroll-view@git+https://github.com/brunocascio/react-native-invertible-scroll-view.git":
-  version "1.0.0"
-  resolved "git+https://github.com/brunocascio/react-native-invertible-scroll-view.git#6ba602621726450228a7ba0b60c92a8e13fd2bce"
+react-native-invertible-scroll-view@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-invertible-scroll-view/-/react-native-invertible-scroll-view-1.1.0.tgz#bfd50a3f5d66ca12639b7c7a9844ceddd1d16890"
   dependencies:
     create-react-class "^15.6.0"
     prop-types "^15.5.10"
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
-"react-native-lightbox@git+https://github.com/brunocascio/react-native-lightbox.git":
-  version "0.6.0"
-  resolved "git+https://github.com/brunocascio/react-native-lightbox.git#878db6896d6e09f703e44b27e3eb25b21573963c"
+react-native-lightbox@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-lightbox/-/react-native-lightbox-0.7.0.tgz#e52b4d7fcc141f59d7b23f0180de535e35b20ec9"
   dependencies:
-    create-react-class "^15.6.0"
     prop-types "^15.5.10"
-    react-timer-mixin "^0.13.3"
 
-"react-native-parsed-text@git+https://github.com/brunocascio/react-native-parsed-text.git":
-  version "0.0.18"
-  resolved "git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064"
+react-native-parsed-text@^0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/react-native-parsed-text/-/react-native-parsed-text-0.0.19.tgz#1aacca6f9ee82f939f60ef985df90c97bd55c45a"
   dependencies:
     prop-types "^15.5.10"
 
 react-native-scrollable-mixin@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
-
-react-timer-mixin@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,8 +84,8 @@ arrify@^1.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
 asap@~2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 ast-types-flow@0.0.7:
   version "0.0.7"
@@ -145,8 +145,8 @@ charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
 
 circular-json@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -256,8 +256,8 @@ doctrine@^2.0.0:
     isarray "^1.0.0"
 
 emoji-regex@^6.1.0:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.3.tgz#6ac2ac58d4b78def5e39b33fcbf395688af3076c"
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -289,8 +289,8 @@ es-to-primitive@^1.1.1:
     is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.23"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
+  version "0.10.24"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.24.tgz#a55877c9924bc0c8d9bd3c2cbe17495ac1709b14"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
@@ -354,8 +354,10 @@ escope@^3.6.0:
     estraverse "^4.1.1"
 
 eslint-config-airbnb-base@^11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.2.0.tgz#19a9dc4481a26f70904545ec040116876018f853"
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz#c0ab108c9beed503cb999e4c60f4ef98eda0ed30"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
 
 eslint-config-airbnb@15.0.2:
   version "15.0.2"
@@ -419,6 +421,10 @@ eslint-plugin-react@7.1.0:
     doctrine "^2.0.0"
     has "^1.0.1"
     jsx-ast-utils "^1.4.1"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
 eslint@3.19.0:
   version "3.19.0"
@@ -508,8 +514,8 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
 fbjs@^0.8.9:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -1024,10 +1030,12 @@ react-native-communications@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-native-communications/-/react-native-communications-2.2.1.tgz#7883b56b20a002eeb790c113f8616ea8692ca795"
 
-react-native-invertible-scroll-view@1.0.0:
+"react-native-invertible-scroll-view@git+https://github.com/brunocascio/react-native-invertible-scroll-view.git":
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-invertible-scroll-view/-/react-native-invertible-scroll-view-1.0.0.tgz#60ceb384dc950c34eba3a5aeda39f97cdc7d4e23"
+  resolved "git+https://github.com/brunocascio/react-native-invertible-scroll-view.git#6ba602621726450228a7ba0b60c92a8e13fd2bce"
   dependencies:
+    create-react-class "^15.6.0"
+    prop-types "^15.5.10"
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
@@ -1039,7 +1047,7 @@ react-native-invertible-scroll-view@1.0.0:
     prop-types "^15.5.10"
     react-timer-mixin "^0.13.3"
 
-"react-native-parsed-text@git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064":
+"react-native-parsed-text@git+https://github.com/brunocascio/react-native-parsed-text.git":
   version "0.0.18"
   resolved "git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064"
   dependencies:
@@ -1106,8 +1114,8 @@ resolve-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve@^1.1.6, resolve@^1.2.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
 
@@ -1139,8 +1147,8 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
 "semver@2 || 3 || 4 || 5":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -1189,8 +1197,8 @@ string-width@^1.0.1:
     strip-ansi "^3.0.0"
 
 string-width@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.0.tgz#030664561fc146c9423ec7d978fe2457437fe6d0"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
@@ -1259,8 +1267,8 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 ua-parser-js@^0.7.9:
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.13.tgz#cd9dd2f86493b3f44dbeeef3780fda74c5ee14be"
+  version "0.7.14"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
 user-home@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,14 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+create-react-class@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -882,7 +890,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1023,10 +1031,12 @@ react-native-invertible-scroll-view@1.0.0:
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
-react-native-lightbox@oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875:
+"react-native-lightbox@git+https://github.com/brunocascio/react-native-lightbox.git":
   version "0.6.0"
-  resolved "https://codeload.github.com/oblador/react-native-lightbox/tar.gz/c84a8543d4511fe6a44c3d7820747c9c1bddd875"
+  resolved "git+https://github.com/brunocascio/react-native-lightbox.git#878db6896d6e09f703e44b27e3eb25b21573963c"
   dependencies:
+    create-react-class "^15.6.0"
+    prop-types "^15.5.10"
     react-timer-mixin "^0.13.3"
 
 "react-native-parsed-text@git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,9 +1029,11 @@ react-native-lightbox@oblador/react-native-lightbox#c84a8543d4511fe6a44c3d782074
   dependencies:
     react-timer-mixin "^0.13.3"
 
-react-native-parsed-text@0.0.18:
+"react-native-parsed-text@git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064":
   version "0.0.18"
-  resolved "https://registry.yarnpkg.com/react-native-parsed-text/-/react-native-parsed-text-0.0.18.tgz#b528eb6f1410f552d2e3fd8d80da7ff0a7890c71"
+  resolved "git+https://github.com/brunocascio/react-native-parsed-text.git#08b864e10e5b65298c628cafd9231fb28f7e4064"
+  dependencies:
+    prop-types "^15.5.10"
 
 react-native-scrollable-mixin@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Since React 16 use `prop-types` as an external package, in order to use `PropTypes`, I've just added this in my fork.

I've made PRs on the plugins as well: 

https://github.com/taskrabbit/react-native-parsed-text/pull/34 (Merged)

https://github.com/expo/react-native-invertible-scroll-view/pull/49 (Merged)

https://github.com/oblador/react-native-lightbox/pull/75 (PR of @formula1) (Merged)