### PR TITLE
Fix wrong order of actions in onPhonePress()

### DIFF
--- a/src/MessageText.js
+++ b/src/MessageText.js
@@ -47,10 +47,10 @@ export default class MessageText extends React.Component {
     (buttonIndex) => {
       switch (buttonIndex) {
         case 0:
-          Communications.phonecall(phone, true);
+          Communications.text(phone);
           break;
         case 1:
-          Communications.text(phone);
+          Communications.phonecall(phone, true);
           break;
       }
     });


### PR DESCRIPTION
The order of the actions index should be the same as the options of action sheet.