### PR TITLE
Update invertible-scroll-view dependency to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "moment": "2.18.1",
     "prop-types": "15.5.10",
     "react-native-communications": "2.2.1",
-    "react-native-invertible-scroll-view": "1.0.0",
+    "react-native-invertible-scroll-view": "1.1.0",
     "react-native-lightbox": "oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875",
     "react-native-parsed-text": "0.0.18",
     "shallowequal": "1.0.2",


### PR DESCRIPTION
The 1.1.0 version addresses the issue in #523 for the react-native-invertible-scroll-view library.