### PR TITLE
Add `onInitialized` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ e.g.
 - **`keyboardShouldPersistTaps`** _(Enum)_ - Determines whether the keyboard should stay visible after a tap; see [`<ScrollView>`](https://facebook.github.io/react-native/docs/scrollview.html) docs
 - **`onInputTextChanged`** _(Function)_ - Callback when the input text changes
 - **`maxInputLength`** _(Integer)_ - Max message composer TextInput length
-- **`parsePatterns`** _(Function)_ - Custom parse patterns for [react-native-parsed-text](https://github.com/taskrabbit/react-native-parsed-text) used to linkify message content (like URLs and phone numbers), e.g.:
+- **`parsePatterns`** _(Function)_ - Custom parse patterns for
+- **`onInitialized`** _(Function)_ - Callback when the chat finished initializing [react-native-parsed-text](https://github.com/taskrabbit/react-native-parsed-text) used to linkify message content (like URLs and phone numbers), e.g.:
 
     ```js
     <GiftedChat

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ e.g.
 - **`keyboardShouldPersistTaps`** _(Enum)_ - Determines whether the keyboard should stay visible after a tap; see [`<ScrollView>`](https://facebook.github.io/react-native/docs/scrollview.html) docs
 - **`onInputTextChanged`** _(Function)_ - Callback when the input text changes
 - **`maxInputLength`** _(Integer)_ - Max message composer TextInput length
-- **`parsePatterns`** _(Function)_ - Custom parse patterns for
-- **`onInitialized`** _(Function)_ - Callback when the chat finished initializing [react-native-parsed-text](https://github.com/taskrabbit/react-native-parsed-text) used to linkify message content (like URLs and phone numbers), e.g.:
+- **`parsePatterns`** _(Function)_ - Custom parse patterns for [react-native-parsed-text](https://github.com/taskrabbit/react-native-parsed-text) used to linkify message content (like URLs and phone numbers), e.g.:
 
     ```js
     <GiftedChat
@@ -161,6 +160,8 @@ e.g.
       ]}
     />
     ```
+
+- **`onInitialized`** _(Function)_ - Callback when the chat finished initializing
 
 ## Imperative methods
 

--- a/example/App.js
+++ b/example/App.js
@@ -27,6 +27,7 @@ export default class Example extends React.Component {
     this.renderBubble = this.renderBubble.bind(this);
     this.renderFooter = this.renderFooter.bind(this);
     this.onLoadEarlier = this.onLoadEarlier.bind(this);
+    this.onInitialized = this.onInitialized.bind(this);
 
     this._isAlright = null;
   }
@@ -73,6 +74,10 @@ export default class Example extends React.Component {
 
     // for demo purpose
     this.answerDemo(messages);
+  }
+
+  onInitialized() {
+    console.log('Chat initialized');
   }
 
   answerDemo(messages) {
@@ -203,6 +208,8 @@ export default class Example extends React.Component {
         renderBubble={this.renderBubble}
         renderCustomView={this.renderCustomView}
         renderFooter={this.renderFooter}
+
+        onInitialized={this.onInitialized}
       />
     );
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-native-communications": "2.2.1",
     "react-native-invertible-scroll-view": "1.0.0",
     "react-native-lightbox": "oblador/react-native-lightbox#c84a8543d4511fe6a44c3d7820747c9c1bddd875",
-    "react-native-parsed-text": "0.0.18",
+    "react-native-parsed-text": "0.0.19",
     "shallowequal": "1.0.2",
     "uuid": "3.1.0"
   }

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -399,6 +399,12 @@ class GiftedChat extends React.Component {
     }
   }
 
+  notifyInitialized() {
+    if (this.props.onInitialized) {
+      this.props.onInitialized();
+    }
+  }
+
   onInitialLayoutViewLayout(e) {
     const layout = e.nativeEvent.layout;
     if (layout.height <= 0) {
@@ -414,6 +420,7 @@ class GiftedChat extends React.Component {
       composerHeight: newComposerHeight,
       messagesContainerHeight: this.prepareMessagesContainerHeight(newMessagesContainerHeight),
     });
+    this.notifyInitialized();
   }
 
   onMainViewLayout(e) {
@@ -554,6 +561,7 @@ GiftedChat.defaultProps = {
   }),
   onInputTextChanged: null,
   maxInputLength: null,
+  onInitialized: null,
 };
 
 GiftedChat.propTypes = {
@@ -600,6 +608,7 @@ GiftedChat.propTypes = {
   keyboardShouldPersistTaps: PropTypes.oneOf(['always', 'never', 'handled']),
   onInputTextChanged: PropTypes.func,
   maxInputLength: PropTypes.number,
+  onInitialized: PropTypes.func,
 };
 
 export {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,9 +1029,11 @@ react-native-lightbox@oblador/react-native-lightbox#c84a8543d4511fe6a44c3d782074
   dependencies:
     react-timer-mixin "^0.13.3"
 
-react-native-parsed-text@0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/react-native-parsed-text/-/react-native-parsed-text-0.0.18.tgz#b528eb6f1410f552d2e3fd8d80da7ff0a7890c71"
+react-native-parsed-text@0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/react-native-parsed-text/-/react-native-parsed-text-0.0.19.tgz#1aacca6f9ee82f939f60ef985df90c97bd55c45a"
+  dependencies:
+    prop-types "^15.5.10"
 
 react-native-scrollable-mixin@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Add an option to get notified when the chat finished initialization.
Our scenario was that we use `onInputTextChanged` and `text` props, but wanted to ignore `onInputTextChanged` events before the chat was initialized.

Another option is to change when `notifyInputTextReset` is called in `onInitialLayoutViewLayout` though I'm not sure if that is the right way to tackle this