### PR TITLE
fix(keyboard height): fix on android & expo TextInput no show

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -169,7 +169,7 @@ class GiftedChat extends React.Component {
   }
 
   getKeyboardHeight() {
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' && !this.props.forceGetKeyboardHeight) {
       // For android: on-screen keyboard resized main container and has own height.
       // @see https://developer.android.com/training/keyboard-input/visibility.html
       // So for calculate the messages container height ignore keyboard height.
@@ -554,6 +554,7 @@ GiftedChat.defaultProps = {
   }),
   onInputTextChanged: null,
   maxInputLength: null,
+  forceGetKeyboardHeight: false,
 };
 
 GiftedChat.propTypes = {
@@ -600,6 +601,7 @@ GiftedChat.propTypes = {
   keyboardShouldPersistTaps: PropTypes.oneOf(['always', 'never', 'handled']),
   onInputTextChanged: PropTypes.func,
   maxInputLength: PropTypes.number,
+  forceGetKeyboardHeight: PropTypes.bool,
 };
 
 export {


### PR DESCRIPTION
* adding forceGetKeyboardHeight props
* fixes https://github.com/FaridSafi/react-native-gifted-chat/issues/461
* fixes https://github.com/FaridSafi/react-native-gifted-chat/issues/518