### PR TITLE
Update moment to fix #597

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "cribspot/react-native-action-sheet#b422c54f26d30b9e85eb14a882ea9cec38600730",
     "md5": "2.2.1",
-    "moment": "2.18.1",
+    "moment": "2.19.0",
     "prop-types": "15.5.10",
     "react-native-communications": "2.2.1",
     "react-native-invertible-scroll-view": "1.0.0",


### PR DESCRIPTION
Basically, the `metro-bundler` never accepted the way moment worked with dynamic imports. But 2.19.0 fixes that and allows the lib to be used on RN >=49.0.

Read here for [more details](https://github.com/facebook/metro-bundler/issues/65#issuecomment-335524547).