### PR TITLE
Replace moment-with-locales.min with regular moment

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -7,7 +7,7 @@ import {
   ViewPropTypes,
 } from 'react-native';
 
-import moment from 'moment/min/moment-with-locales.min';
+import moment from 'moment';
 
 import { isSameDay, isSameUser, warnDeprecated } from './utils';
 

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 
 import ActionSheet from '@expo/react-native-action-sheet';
-import moment from 'moment/min/moment-with-locales.min';
+import moment from 'moment';
 import uuid from 'uuid';
 
 import * as utils from './utils';

--- a/src/Time.js
+++ b/src/Time.js
@@ -7,7 +7,7 @@ import {
   ViewPropTypes,
 } from 'react-native';
 
-import moment from 'moment/min/moment-with-locales.min';
+import moment from 'moment';
 
 export default class Time extends React.Component {
   render() {


### PR DESCRIPTION
After upgrade to `react-native@0.49.3` and `moment@2.19.1` I got error:

```
moment-with-locales.min.js require() must have a single string literal argument
```

Turns out `react-native-gifted-chat` explicitly import from 'moment/min/moment-with-locales.min';
Removing this fixes my build. In my project I use non-english locale and everything seems to be ok after switch to original `moment`.

If `moment/min/moment-with-locales.min` is imported on purpose please close this PR.