### PR TITLE
OnPress event on Bubble

### DIFF
--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -239,7 +239,7 @@ Bubble.defaultProps = {
 Bubble.propTypes = {
   touchableProps: PropTypes.object,
   onLongPress: PropTypes.func,
-  onPress: PropTypes.fubc,
+  onPress: PropTypes.func,
   renderMessageImage: PropTypes.func,
   renderMessageText: PropTypes.func,
   renderCustomView: PropTypes.func,

--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -19,6 +19,7 @@ export default class Bubble extends React.Component {
   constructor(props) {
     super(props);
     this.onLongPress = this.onLongPress.bind(this);
+    this.onPress = this.onPress.bind(this);
   }
 
   handleBubbleToNext() {
@@ -117,6 +118,12 @@ export default class Bubble extends React.Component {
       }
     }
   }
+  
+  onPress() {
+    if (this.props.onPress) {
+      this.props.onPress(this.context, this.props.currentMessage);
+    }
+  }
 
   render() {
     return (
@@ -124,6 +131,7 @@ export default class Bubble extends React.Component {
         <View style={[styles[this.props.position].wrapper, this.props.wrapperStyle[this.props.position], this.handleBubbleToNext(), this.handleBubbleToPrevious()]}>
           <TouchableWithoutFeedback
             onLongPress={this.onLongPress}
+            onPress={this.onPress}
             accessibilityTraits="text"
             {...this.props.touchableProps}
           >
@@ -204,6 +212,7 @@ Bubble.contextTypes = {
 Bubble.defaultProps = {
   touchableProps: {},
   onLongPress: null,
+  onPress: null,
   renderMessageImage: null,
   renderMessageText: null,
   renderCustomView: null,
@@ -230,6 +239,7 @@ Bubble.defaultProps = {
 Bubble.propTypes = {
   touchableProps: PropTypes.object,
   onLongPress: PropTypes.func,
+  onPress: PropTypes.fubc,
   renderMessageImage: PropTypes.func,
   renderMessageText: PropTypes.func,
   renderCustomView: PropTypes.func,


### PR DESCRIPTION
This adds an onPress event on the Bubble because even with wrapping the Bubble with TouchableNoHighlight, the tap,press event on Bubble never bubbles up to the TouchableNoHighlight

A typical use case is show options like Like, Share etc...which is not appropriate for LongPress