### PR TITLE
Inverted prop for reverse messages display order

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ e.g. System Message
 - **`renderBubble`** _(Function)_ - Custom message bubble
 - **`renderSystemMessage`** _(Function)_ - Custom system message
 - **`onLongPress`** _(Function(`context`, `message`))_ - Callback when a message bubble is long-pressed; default is to show an ActionSheet with "Copy Text" (see [example using `showActionSheetWithOptions()`](https://github.com/FaridSafi/react-native-gifted-chat/blob/master@%7B2017-09-25%7D/src/Bubble.js#L96-L119))
+- **`inverted`** _(Bool)_ - Reverses display order of `messages`; default is `true`
 - **`renderMessage`** _(Function)_ - Custom message container
 - **`renderMessageText`** _(Function)_ - Custom message text
 - **`renderMessageImage`** _(Function)_ - Custom message image

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -84,14 +84,14 @@ class GiftedChat extends React.Component {
     if (!Array.isArray(messages)) {
       messages = [messages];
     }
-    return this.inverted ? messages.concat(currentMessages) : currentMessages.concat(messages);
+    return this.props.inverted ? messages.concat(currentMessages) : currentMessages.concat(messages);
   }
 
   static prepend(currentMessages = [], messages) {
     if (!Array.isArray(messages)) {
       messages = [messages];
     }
-    return this.inverted ? currentMessages.concat(messages) : messages.concat(currentMessages);
+    return this.props.inverted ? currentMessages.concat(messages) : messages.concat(currentMessages);
   }
 
   getChildContext() {

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -71,7 +71,7 @@ class GiftedChat extends React.Component {
 
 
     this.invertibleScrollViewProps = {
-      inverted: true,
+      inverted: this.props.inverted,
       keyboardShouldPersistTaps: this.props.keyboardShouldPersistTaps,
       onKeyboardWillShow: this.onKeyboardWillShow,
       onKeyboardWillHide: this.onKeyboardWillHide,
@@ -84,14 +84,14 @@ class GiftedChat extends React.Component {
     if (!Array.isArray(messages)) {
       messages = [messages];
     }
-    return messages.concat(currentMessages);
+    return this.inverted ? messages.concat(currentMessages) : currentMessages.concat(messages);
   }
 
   static prepend(currentMessages = [], messages) {
     if (!Array.isArray(messages)) {
       messages = [messages];
     }
-    return currentMessages.concat(messages);
+    return this.inverted ? currentMessages.concat(messages) : messages.concat(currentMessages);
   }
 
   getChildContext() {
@@ -557,6 +557,7 @@ GiftedChat.defaultProps = {
   onInputTextChanged: null,
   maxInputLength: null,
   forceGetKeyboardHeight: false,
+  inverted: true,
 };
 
 GiftedChat.propTypes = {
@@ -605,6 +606,7 @@ GiftedChat.propTypes = {
   onInputTextChanged: PropTypes.func,
   maxInputLength: PropTypes.number,
   forceGetKeyboardHeight: PropTypes.bool,
+  inverted: PropTypes.bool,
 };
 
 export {

--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -156,8 +156,8 @@ export default class MessageContainer extends React.Component {
           dataSource={this.state.dataSource}
 
           renderRow={this.renderRow}
-          renderHeader={this.renderFooter}
-          renderFooter={this.renderLoadEarlier}
+          renderHeader={this.props.inverted ? this.renderFooter : this.renderLoadEarlier}
+          renderFooter={this.props.inverted ? this.renderLoadEarlier : this.renderFooter}
           renderScrollComponent={this.renderScrollComponent}
         />
       </View>


### PR DESCRIPTION
Amendment to the #489 PR allow the user to set a prop to reverse the `messages` display order on the scroll view.

 **`inverted`** _(Bool)_ - Reverses display order of `messages`; default is `true`