### PR TITLE
Unnecessary semicolon removed

### DIFF
--- a/example/data/old_messages.js
+++ b/example/data/old_messages.js
@@ -24,4 +24,4 @@ module.exports = [
     createdAt: new Date(Date.UTC(2016, 7, 30, 17, 20, 0)),
     system: true
   }
-];;
+];


### PR DESCRIPTION
This file was ending with 2 semicolons, this produces Unnecessary semicolon error. By this update the file is error free.