### PR TITLE
fix(onPressActionButton): no default

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -94,7 +94,6 @@ Actions.defaultProps = {
   containerStyle: {},
   iconTextStyle: {},
   wrapperStyle: {},
-  onPressActionButton: () => { },
 };
 
 Actions.propTypes = {


### PR DESCRIPTION
Fix https://github.com/FaridSafi/react-native-gifted-chat/issues/683