### PR TITLE
Fix issue with inverted

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -313,7 +313,7 @@ class GiftedChat extends React.Component {
         <MessageContainer
           {...this.props}
           invertibleScrollViewProps={this.invertibleScrollViewProps}
-          messages={this.getMessages()}
+          messages={this.props.inverted ? this.getMessages().reverse() : this.getMessages()}
           ref={(component) => (this._messageContainerRef = component)}
 
         />
@@ -532,6 +532,7 @@ GiftedChat.defaultProps = {
   renderBubble: null,
   renderSystemMessage: null,
   onLongPress: null,
+  inverted: true,
   renderMessage: null,
   renderMessageText: null,
   renderMessageImage: null,
@@ -585,6 +586,7 @@ GiftedChat.propTypes = {
   renderBubble: PropTypes.func,
   renderSystemMessage: PropTypes.func,
   onLongPress: PropTypes.func,
+  inverted: PropTypes.func,
   renderMessage: PropTypes.func,
   renderMessageText: PropTypes.func,
   renderMessageImage: PropTypes.func,


### PR DESCRIPTION
When running `npm install react-native-gifted-chat --save` I get a different version of `GiftedChat.js` than is on the master branch on github. 

the `inverted` prop doesn't work on the messages after installing this library through `npm` so I updated my code locally to use what is on `master`. However this still didn't resolve the issue. 

I am not sure where the `static` functions of [`append`](https://github.com/FaridSafi/react-native-gifted-chat/blob/master/src/GiftedChat.js#L84) and [`prepend`](https://github.com/FaridSafi/react-native-gifted-chat/blob/master/src/GiftedChat.js#L91) are getting called, but as far as I could tell they aren't being called when the component mounts. 

I created a fix here myself which does resolve the issue, although I have not tested it extensively. I guess it would be a good idea to add tests to this library.