### PR TITLE
Add Prop to always show avatars for each message

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ e.g. System Message
 * **`renderLoadEarlier`** _(Function)_ - Custom "Load earlier messages" button
 * **`renderAvatar`** _(Function)_ - Custom message avatar; set to `null` to not render any avatar for the message
 * **`showUserAvatar`** _(Bool)_ - Whether to render an avatar for the current user; default is `false`, only show avatars for other users
-* **`showAvatarForEveryMessage`** _(Bool)_ - When false, avatars will only be displayed when a consecutive message is from the user on the same day; default is `false`
+* **`showAvatarForEveryMessage`** _(Bool)_ - When false, avatars will only be displayed when a consecutive message is from the same user on the same day; default is `false`
 * **`onPressAvatar`** _(Function(`user`))_ - Callback when a message avatar is tapped
 * **`renderAvatarOnTop`** _(Bool)_ - Render the message avatar at the top of consecutive messages, rather than the bottom; default is `false`
 * **`renderBubble`** _(Function)_ - Custom message bubble

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ e.g. System Message
 * **`renderLoadEarlier`** _(Function)_ - Custom "Load earlier messages" button
 * **`renderAvatar`** _(Function)_ - Custom message avatar; set to `null` to not render any avatar for the message
 * **`showUserAvatar`** _(Bool)_ - Whether to render an avatar for the current user; default is `false`, only show avatars for other users
+* **`showAvatarForEveryMessage`** _(Bool)_ - When false, avatars will only be displayed when a consecutive message is from the user on the same day; default is `false`
 * **`onPressAvatar`** _(Function(`user`))_ - Callback when a message avatar is tapped
 * **`renderAvatarOnTop`** _(Bool)_ - Render the message avatar at the top of consecutive messages, rather than the bottom; default is `false`
 * **`renderBubble`** _(Function)_ - Custom message bubble

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -26,7 +26,7 @@ export default class Avatar extends React.Component {
   }
 
   render() {
-    const { renderAvatarOnTop } = this.props;
+    const { renderAvatarOnTop, showAvatarForEveryMessage } = this.props;
     const messageToCompare = renderAvatarOnTop ? this.props.previousMessage : this.props.nextMessage;
     const computedStyle = renderAvatarOnTop ? 'onTop' : 'onBottom';
 
@@ -35,6 +35,7 @@ export default class Avatar extends React.Component {
     }
 
     if (
+      !showAvatarForEveryMessage &&
       isSameUser(this.props.currentMessage, messageToCompare) &&
       isSameDay(this.props.currentMessage, messageToCompare)
     ) {
@@ -98,6 +99,7 @@ const styles = {
 
 Avatar.defaultProps = {
   renderAvatarOnTop: false,
+  showAvatarForEveryMessage: false,
   position: 'left',
   currentMessage: {
     user: null,
@@ -114,6 +116,7 @@ Avatar.defaultProps = {
 
 Avatar.propTypes = {
   renderAvatarOnTop: PropTypes.bool,
+  showAvatarForEveryMessage: PropTypes.bool,
   position: PropTypes.oneOf(['left', 'right']),
   currentMessage: PropTypes.object,
   previousMessage: PropTypes.object,


### PR DESCRIPTION
Resolves #507 #611 

Current behaviour only shows avatars if the consecutive message's timestamp and user is different. This will allow the user to toggle avatars to always show. Defaults to `false` to maintain existing behaviour.


Usage:
```react
   <GiftedChat
          showAvatarForEveryMessage={true}
        />
```