### PR TITLE
Fix initials not changing on user.name prop change

### DIFF
--- a/src/GiftedAvatar.js
+++ b/src/GiftedAvatar.js
@@ -10,7 +10,7 @@ const { carrot, emerald, peterRiver, wisteria, alizarin, turquoise, midnightBlue
 // 3 words name initials
 // handle only alpha numeric chars
 
-export default class GiftedAvatar extends React.Component {
+export default class GiftedAvatar extends React.PureComponent {
   setAvatarColor() {
     const userName = this.props.user.name || '';
     const name = userName.toUpperCase().split(' ');
@@ -86,9 +86,7 @@ export default class GiftedAvatar extends React.Component {
       );
     }
 
-    if (!this.avatarColor) {
-      this.setAvatarColor();
-    }
+    this.setAvatarColor();
 
     return (
       <TouchableOpacity


### PR DESCRIPTION
Fixes #745

Also converted `GiftedAvatar` to extend `PureComponent` instead to prevent re-rendering when props do not change at all.

##### GIF
<center>

| ![feb-09-2018 16-39-45](https://user-images.githubusercontent.com/1752354/36018860-3df8f2e0-0db8-11e8-9112-6580de87eeb3.gif) | ![feb-09-2018 20-48-44](https://user-images.githubusercontent.com/1752354/36028628-b3cfc5da-0dda-11e8-8a19-7909e35f1587.gif) |
|:---:|:---:|
| Before | Now  |

</center>