### PR TITLE
Add moment as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "react-native-parsed-text": "^0.0.20",
     "shallowequal": "1.0.2",
     "uuid": "3.2.1"
+  },
+  "peerDependencies": {
+    "moment": "^2.19.0"
   }
 }


### PR DESCRIPTION
If the depending project uses another version of moment, importing languages won't work because it will be created two different instances. This PR adds moment to peerDependencies to ensure that the same version om moment is being used. 

Resolves #762. 

edit: I started by just moving it to peerDependecies, but since this repo also needs moment, this broke a lot of tests. I figured I could have moment as both a dependency and a peerDependecy. I'm not 100% sure that this is correct, but that was my best guess. 