### PR TITLE
Ensure react-native-web compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "@expo/react-native-action-sheet": "git+https://github.com/PeterKottas/react-native-action-sheet#50d21a045c8272a61b06dd1a728d61493d25d7f1",
+    "@expo/react-native-action-sheet": "git+https://github.com/PeterKottas/react-native-action-sheet#8867a9d413ad6f86ace22a1693eacd04302c0866",
     "md5": "2.2.1",
     "moment": "^2.19.0",
     "prop-types": "15.6.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "@expo/react-native-action-sheet": "^1.0.1",
+    "@expo/react-native-action-sheet": "git+https://github.com/PeterKottas/react-native-action-sheet#50d21a045c8272a61b06dd1a728d61493d25d7f1",
     "md5": "2.2.1",
     "moment": "^2.19.0",
     "prop-types": "15.6.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-communications": "2.2.1",
     "react-native-invertible-scroll-view": "^1.1.0",
     "react-native-lightbox": "^0.7.0",
-    "react-native-parsed-text": "^0.0.20",
+    "react-native-parsed-text": "git+https://github.com/PeterKottas/react-native-parsed-text#2a51e33fcd2c04ca7f2da0c8f5e46c7504faf5b0",
     "shallowequal": "1.0.2",
     "uuid": "3.2.1"
   }

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -8,7 +8,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Animated, Platform, StyleSheet, View } from 'react-native';
+import { Animated, Platform, StyleSheet, View, Platform } from 'react-native';
 
 import ActionSheet from '@expo/react-native-action-sheet';
 import moment from 'moment';

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -8,7 +8,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Animated, Platform, StyleSheet, View, Platform } from 'react-native';
+import { Animated, StyleSheet, View, Platform } from 'react-native';
 
 import ActionSheet from '@expo/react-native-action-sheet';
 import moment from 'moment';

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -74,10 +74,13 @@ class GiftedChat extends React.Component {
     this.invertibleScrollViewProps = {
       inverted: this.props.inverted,
       keyboardShouldPersistTaps: this.props.keyboardShouldPersistTaps,
-      onKeyboardWillShow: this.onKeyboardWillShow,
-      onKeyboardWillHide: this.onKeyboardWillHide,
-      onKeyboardDidShow: this.onKeyboardDidShow,
-      onKeyboardDidHide: this.onKeyboardDidHide,
+      ...(Platform.OS !== 'web'? {
+        onKeyboardWillShow: this.onKeyboardWillShow,
+        onKeyboardWillHide: this.onKeyboardWillHide,
+        onKeyboardDidShow: this.onKeyboardDidShow,
+        onKeyboardDidHide: this.onKeyboardDidHide
+        }:{}
+      )
     };
   }
 

--- a/src/InputToolbar.js
+++ b/src/InputToolbar.js
@@ -2,7 +2,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { StyleSheet, View, Keyboard, ViewPropTypes, Dimensions } from 'react-native';
+import { StyleSheet, View, Keyboard, ViewPropTypes, Dimensions, Platform } from 'react-native';
 
 import Composer from './Composer';
 import Send from './Send';

--- a/src/InputToolbar.js
+++ b/src/InputToolbar.js
@@ -23,13 +23,17 @@ export default class InputToolbar extends React.Component {
   }
 
   componentWillMount() {
-    this.keyboardWillShowListener = Keyboard.addListener('keyboardWillShow', this.keyboardWillShow);
-    this.keyboardWillHideListener = Keyboard.addListener('keyboardWillHide', this.keyboardWillHide);
+    if(Platform.OS !== 'web') {  
+      this.keyboardWillShowListener = Keyboard.addListener('keyboardWillShow', this.keyboardWillShow);
+      this.keyboardWillHideListener = Keyboard.addListener('keyboardWillHide', this.keyboardWillHide);
+    }
   }
 
   componentWillUnmount() {
-    this.keyboardWillShowListener.remove();
-    this.keyboardWillHideListener.remove();
+    if(Platform.OS !== 'web') {  
+      this.keyboardWillShowListener.remove();
+      this.keyboardWillHideListener.remove();
+    }
   }
 
   keyboardWillShow() {
@@ -102,7 +106,7 @@ const styles = StyleSheet.create({
     borderTopColor: Color.defaultColor,
     backgroundColor: Color.white,
     bottom: 0,
-    width: Dimensions.get('window').width,
+    width: Platform.OS === 'web' ? '100%' : Dimensions.get('window').width,
   },
   primary: {
     flexDirection: 'row',

--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -79,7 +79,7 @@ export default class MessageContainer extends React.Component {
   }
 
   scrollTo(options) {
-    this._invertibleScrollViewRef.scrollTo(options);
+    this._invertibleScrollViewRef && this._invertibleScrollViewRef.scrollTo(options);
   }
 
   renderLoadEarlier() {


### PR DESCRIPTION
This PR makes this lib 100% compatible with react-native-web. Please note this is not yet final, I am opening the PR to give you a chance to look at it and make suggestions. As you can see from package.json, 2 libs had to be replaced with forks so I first need to orchestrate updated release of those before we can have stable version out.
Atm, I am also working on invertible-scroll-view which doesn't work on web. Will let you know once everything is done. In the meantime, folks can use "react-native-gifted-chat": "git+https://github.com/PeterKottas/react-native-gifted-chat#ab3f65dd5883a7cad3691c6accf570a56f245b8d", for testing on web. (it's pretty neat already! ;))