### PR TITLE
Replace hardcoded width set to full screen width

### DIFF
--- a/src/InputToolbar.js
+++ b/src/InputToolbar.js
@@ -102,7 +102,8 @@ const styles = StyleSheet.create({
     borderTopColor: Color.defaultColor,
     backgroundColor: Color.white,
     bottom: 0,
-    width: Dimensions.get('window').width,
+    left: 0,
+    right: 0,
   },
   primary: {
     flexDirection: 'row',

--- a/src/InputToolbar.js
+++ b/src/InputToolbar.js
@@ -2,7 +2,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { StyleSheet, View, Keyboard, ViewPropTypes, Dimensions } from 'react-native';
+import { StyleSheet, View, Keyboard, ViewPropTypes } from 'react-native';
 
 import Composer from './Composer';
 import Send from './Send';

--- a/src/__tests__/__snapshots__/InputToolbar.test.js.snap
+++ b/src/__tests__/__snapshots__/InputToolbar.test.js.snap
@@ -9,7 +9,8 @@ exports[`should render <InputToolbar /> and compare with snapshot 1`] = `
         "borderTopColor": "#b2b2b2",
         "borderTopWidth": 0.5,
         "bottom": 0,
-        "width": 750,
+        "left": 0,
+        "right": 0,
       },
       Object {},
       Object {


### PR DESCRIPTION
`InputToolbar` has hardcoded width set to full screen width.

That fails when `GiftedChat` is not used full screen, part of the input is hidden:

![simulator screen shot - ipad air 2 - 2018-03-01 at 14 28 06](https://user-images.githubusercontent.com/387611/36846942-e9a4b1e8-1d5c-11e8-937b-6675c9f11ed3.png)

After applying the fix, input inherits container width:

![simulator screen shot - ipad air 2 - 2018-03-01 at 14 26 39](https://user-images.githubusercontent.com/387611/36846943-e9d8f782-1d5c-11e8-950e-fe2a231278bd.png)
