### PR TITLE
Fix a bug when custom actions is pressed

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -21,9 +21,9 @@ export default class Actions extends React.Component {
         cancelButtonIndex,
         tintColor: this.props.optionTintColor,
       },
-      function handle(buttonIndex) {
+      (buttonIndex) => {
         let i = 0;
-        Object.keys(this.props.options).forEach(function launch(key) {
+        Object.keys(this.props.options).forEach((key) => {
           if (this.props.options[key]) {
             if (buttonIndex === i) {
               this.props.options[key](this.props);


### PR DESCRIPTION
Because line 24 and line 26 are not using arrow function, `this` is not referring to the component itself. Therefore it throws `undefined is not an object` when trying to evaluate `this.props.options`.

Changing back to arrow function fixed the issue.