### PR TITLE
Added type for showAvatarForEveryMessage in index.d.ts. #731

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -168,6 +168,8 @@ export interface GiftedChatProps {
   renderAvatar?(props: AvatarProps): React.ReactNode;
   /* Whether to render an avatar for the current user; default is false, only show avatars for other users */
   showUserAvatar?: boolean;
+  /* When false, avatars will only be displayed when a consecutive message is from the same user on the same day; default is false */
+  showAvatarForEveryMessage?: boolean;
   /* Callback when a message avatar is tapped */
   onPressAvatar?(user: User): void;
   /* Render the message avatar at the top of consecutive messages, rather than the bottom; default is false */

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.3",
   "description": "The most complete chat UI for React Native",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/FaridSafi/react-native-gifted-chat.git"


### PR DESCRIPTION
Problems Fixed - 
* The type for `showAvatarForEveryMessage` in `GiftedChatProps` was missing in the current typedefs
* Installation of `v0.4.3`using `npm` or `yarn` was not shipping along the type definitions. Reference - https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Detailed discussion here - #731 