### PR TITLE
Fixed MessageContainer to account for reverse order of messages when inverted prop is false

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -14,7 +14,7 @@ export default function Day(
   { dateFormat, currentMessage, previousMessage, nextMessage, containerStyle, wrapperStyle, textStyle, inverted },
   context,
 ) {
-  if (!isSameDay(currentMessage, inverted ? previousMessage : nextMessage)) {
+  if (!isSameDay(currentMessage, previousMessage)) {
     return (
       <View style={[styles.container, containerStyle]}>
         <View style={wrapperStyle}>

--- a/src/Day.js
+++ b/src/Day.js
@@ -11,7 +11,7 @@ import { isSameDay, isSameUser, warnDeprecated } from './utils';
 import { DATE_FORMAT } from './Constant';
 
 export default function Day(
-  { dateFormat, currentMessage, previousMessage, nextMessage, containerStyle, wrapperStyle, textStyle, inverted },
+  { dateFormat, currentMessage, previousMessage, containerStyle, wrapperStyle, textStyle },
   context,
 ) {
   if (!isSameDay(currentMessage, previousMessage)) {
@@ -56,7 +56,6 @@ Day.defaultProps = {
     createdAt: null,
   },
   previousMessage: {},
-  nextMessage: {},
   containerStyle: {},
   wrapperStyle: {},
   textStyle: {},
@@ -69,8 +68,6 @@ Day.defaultProps = {
 Day.propTypes = {
   currentMessage: PropTypes.object,
   previousMessage: PropTypes.object,
-  nextMessage: PropTypes.object,
-  inverted: PropTypes.bool,
   containerStyle: ViewPropTypes.style,
   wrapperStyle: ViewPropTypes.style,
   textStyle: Text.propTypes.style,

--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -60,11 +60,12 @@ export default class MessageContainer extends React.Component {
   }
 
   prepareMessages(messages) {
+    const { inverted } = this.props;
     return {
       keys: messages.map((m) => m._id),
       blob: messages.reduce((o, m, i) => {
-        const previousMessage = messages[i + 1] || {};
-        const nextMessage = messages[i - 1] || {};
+        const previousMessage = inverted ? (messages[i + 1] || {}) : (messages[i - 1] || {});
+        const nextMessage = inverted ? (messages[i - 1] || {}) : (messages[i + 1] || {});
         // add next and previous messages to hash to ensure updates
         const toHash = JSON.stringify(m) + previousMessage._id + nextMessage._id;
         o[m._id] = {


### PR DESCRIPTION
I think this resolves #858 .  Due to bugs in PR #658 and #810 .
