### PR TITLE
Use IMessage type instead of `any` to define the type of message property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ export class GiftedAvatarProps extends React.Component<GiftedAvatarProps> { }
 
 export interface GiftedChatProps {
   /* Messages to display */
-  messages?: any[];
+  messages?: IMessage[];
   /* Input text; default is undefined, but if specified, it will override GiftedChat's internal state */
   text?: string;
   /* Placeholder when text is empty; default is 'Type a message...' */
@@ -183,7 +183,7 @@ export interface GiftedChatProps {
   /* Reverses display order of messages; default is true */
   inverted?: boolean;
   /*Custom message container */
-  renderMessage?(message: any): React.ReactNode;
+  renderMessage?(message: IMessage): React.ReactNode;
   /* Custom message text */
   renderMessageText?(messageText: MessageTextProps): React.ReactNode;
   /* Custom message image */
@@ -234,15 +234,15 @@ export interface GiftedChatProps {
 
 export class GiftedChat extends React.Component<GiftedChatProps> {
   static append(
-    currentMessages: any[],
-    messages: any[],
+    currentMessages: IMessage[],
+    messages: IMessage[],
     inverted?: boolean
-  ): any[];
+  ): IMessage[];
   static prepend(
-    currentMessages: any[],
-    messages: any[],
+    currentMessages: IMessage[],
+    messages: IMessage[],
     inverted?: boolean
-  ): any[];
+  ): IMessage[];
 }
 
 interface InputToolbarProps {


### PR DESCRIPTION
Hello. 
I'm using react-native-gifted-chat with TypeScript. I want `messages` property of GiftedChat component to have a type.
 I considered to write new Interface but found `IMessage` type in the type definition file. It looks good to use as type of `messages` property.
Thanks.