### PR TITLE
Fix typos in TS Types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ interface ComposerProps {
   composerHeight?: number;
   text?: string;
   placeholder?: string;
-  placeholderTextCoolor?: string;
+  placeholderTextColor?: string;
   textInputProps?: Partial<TextInputProperties>;
   onTextChanged?(text: string): void;
   onInputSizeChanged?(contentSize: number): void;
@@ -359,7 +359,7 @@ interface TimeProps {
 export class Time extends React.Component<TimeProps> { }
 
 export type utils = {
-  isSameUser(currrentMessage?: IMessage, message?: IMessage): boolean;
+  isSameUser(currentMessage?: IMessage, message?: IMessage): boolean;
   isSameDay(currentMessage?: IMessage, message?: IMessage): boolean;
   isSameTime(currentMessage?: IMessage, message?: IMessage): boolean;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,9 +86,9 @@ interface BubbleProps {
   bottomContainerStyle: LeftRightStyle<ViewStyle>;
   tickStyle: TextStyle;
   containerToNextStyle: LeftRightStyle<ViewStyle>;
-  containertoPreviousStyle: LeftRightStyle<ViewStyle>;
+  containerToPreviousStyle: LeftRightStyle<ViewStyle>;
   // TODO: remove in next major release
-  isSameDay?(currentMessage: IMessage, inextMessage: IMessage): boolean;
+  isSameDay?(currentMessage: IMessage, nextMessage: IMessage): boolean;
   isSameUser?(currentMessage: IMessage, nextMessage: IMessage): boolean;
 }
 
@@ -117,7 +117,7 @@ interface DayProps {
   wrapperStyle?: ViewStyle;
   textStyle?: TextStyle;
   // TODO: remove in next major release
-  isSameDay?(currentMessage: IMessage, inextMessage: IMessage): boolean;
+  isSameDay?(currentMessage: IMessage, nextMessage: IMessage): boolean;
   isSameUser?(currentMessage: IMessage, nextMessage: IMessage): boolean;
   dateFormat?: string;
 }


### PR DESCRIPTION
I noticed some trivial typos in the index.d.ts.

1. Some of the typos have no effect as they're a typo in the name of a parameter eg. `inextMessage`
2. Some of the typos are actually a mismatch in the real name of the props eg. `containertoPreviousStyle` vs `containerToPreviousStyle` -- looking at the JS code, the correct name is `containerToPreviousStyle`