### PR TITLE
fix: enable renderFooter for FlatList MessageContainer

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -104,10 +104,9 @@ export default class MessageContainer extends React.PureComponent {
           style={styles.listStyle}
           contentContainerStyle={styles.contentContainerStyle}
           renderItem={this.renderRow}
-          renderHeader={this.renderFooter}
-          renderFooter={this.renderLoadEarlier}
           {...this.props.invertibleScrollViewProps}
           ListFooterComponent={this.renderHeaderWrapper}
+          ListHeaderComponent={this.renderFooter}
           {...this.props.listViewProps}
         />
       </View>


### PR DESCRIPTION
This PR fixes renderFooter gifted chat prop not working with the new Flat List implementation of Message Container (#705 ).

Flat List, compared to List View used before, does not recognise `renderFooter` and `renderHeader` props, so, although they were passed, they were ignored.

This PR removes above mentioned props and utilises `ListHeaderComponent` prop which is an alternative of `renderHeader` for Flat List.