### PR TITLE
Add avoidKeyboard prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -230,7 +230,7 @@ export interface GiftedChatProps {
   maxInputLength?: number;
   /* Custom parse patterns for react-native-parsed-text used to linkify message content (like URLs and phone numbers) */
   parsePatterns?(): React.ReactNode;
-  /* Posibility to switch off keyboard avoiding, default is true */ 
+  /* Possibility to switch off keyboard avoiding, default is true */ 
   avoidKeyboard?: boolean
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -231,7 +231,7 @@ export interface GiftedChatProps {
   /* Custom parse patterns for react-native-parsed-text used to linkify message content (like URLs and phone numbers) */
   parsePatterns?(): React.ReactNode;
   /* Possibility to switch off keyboard avoiding, default is true */ 
-  avoidKeyboard?: boolean
+  avoidKeyboard?: boolean;
 }
 
 export class GiftedChat extends React.Component<GiftedChatProps> {

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -561,7 +561,7 @@ GiftedChat.defaultProps = {
   maxInputLength: null,
   forceGetKeyboardHeight: false,
   inverted: true,
-  avoidKeyboard: true
+  avoidKeyboard: true,
 };
 
 GiftedChat.propTypes = {
@@ -612,7 +612,7 @@ GiftedChat.propTypes = {
   forceGetKeyboardHeight: PropTypes.bool,
   inverted: PropTypes.bool,
   textInputProps: PropTypes.object,
-  avoidKeyboard: PropTypes.bool
+  avoidKeyboard: PropTypes.bool,
 };
 
 export {


### PR DESCRIPTION
This prop allows using own implementation of keyboard avoiding on level above of component hierarchy. Especially useful on iOS when chat component doesn't take 100% of the screen height