### PR TITLE
Add prop to customise to Text style of timestamps

### DIFF
--- a/src/Time.js
+++ b/src/Time.js
@@ -9,10 +9,10 @@ import moment from 'moment';
 import Color from './Color';
 import { TIME_FORMAT } from './Constant';
 
-export default function Time({ position, containerStyle, currentMessage, timeFormat, textStyle }, context) {
+export default function Time({ position, containerStyle, currentMessage, timeFormat, textStyle, timeTextStyle }, context) {
   return (
     <View style={[styles[position].container, containerStyle[position]]}>
-      <Text style={[styles[position].text, textStyle[position]]}>
+      <Text style={[styles[position].text, textStyle[position], timeTextStyle[position]]}>
         {moment(currentMessage.createdAt)
           .locale(context.getLocale())
           .format(timeFormat)}
@@ -66,6 +66,7 @@ Time.defaultProps = {
   containerStyle: {},
   textStyle: {},
   timeFormat: TIME_FORMAT,
+  timeTextStyle: {},
 };
 
 Time.propTypes = {
@@ -80,4 +81,8 @@ Time.propTypes = {
     right: Text.propTypes.style,
   }),
   timeFormat: PropTypes.string,
+  timeTextStyle: PropTypes.shape({
+    left: Text.propTypes.style,
+    right: Text.propTypes.style,
+  }),
 };

--- a/src/Time.js
+++ b/src/Time.js
@@ -9,7 +9,10 @@ import moment from 'moment';
 import Color from './Color';
 import { TIME_FORMAT } from './Constant';
 
-export default function Time({ position, containerStyle, currentMessage, timeFormat, textStyle, timeTextStyle }, context) {
+export default function Time(
+  { position, containerStyle, currentMessage, timeFormat, textStyle, timeTextStyle },
+  context,
+) {
   return (
     <View style={[styles[position].container, containerStyle[position]]}>
       <Text style={[styles[position].text, textStyle[position], timeTextStyle[position]]}>

--- a/src/__tests__/__snapshots__/Time.test.js.snap
+++ b/src/__tests__/__snapshots__/Time.test.js.snap
@@ -26,6 +26,7 @@ exports[`should render <Time /> and compare with snapshot 1`] = `
           "textAlign": "right",
         },
         undefined,
+        undefined,
       ]
     }
   >


### PR DESCRIPTION
Example:

```jsx
<GiftedChat
  messages={this.state.messages}
  onSend={this.onSend}
  renderCustomView={CustomView}
  keyboardShouldPersistTaps="never"
  user={{ _id: 1 }}
  renderBubble={props => {
    return (
      <Bubble
        {...props}
        timeTextStyle={{
          right: { color: 'red' }
        }}
      />
    );
  }}
  parsePatterns={this.parsePatterns}
/>
```

<img src="https://user-images.githubusercontent.com/899175/43662642-4b97fd60-976f-11e8-80e8-f4bbe1e781ae.png" width="375" />

Related to #672