### PR TITLE
Fixes calculation of layout while keyboard remains open

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -423,7 +423,7 @@ class GiftedChat extends React.Component {
     if (this.getMaxHeight() !== layout.height || this.getIsFirstLayout() === true) {
       this.setMaxHeight(layout.height);
       this.setState({
-        messagesContainerHeight: this.prepareMessagesContainerHeight(this.getBasicMessagesContainerHeight()),
+        messagesContainerHeight: this.prepareMessagesContainerHeight(this.getMessagesContainerHeightWithKeyboard()),
       });
     }
     if (this.getIsFirstLayout() === true) {


### PR DESCRIPTION
I'm not sure whether this is the correct fix but this solves a problem I had with the height of the chat being miscalculated as full size if another component on the screen is also resized/hidden as a result of the keyboard being shown/hidden.