### PR TITLE
Add prop disableKeyboardAvoiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ e.g. System Message
     ]}
   />
   ```
+* **`disableKeyboardAvoiding`** _(Bool)_ - If true, do not adjust for the onscreen keyboard. Useful if you're managing keyboard avoidance yourself.
 
 ## Imperative methods
 

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -172,7 +172,7 @@ class GiftedChat extends React.Component {
 
   getKeyboardHeight() {
     // if true, then always force keyboard height to zero
-    if (this.props.forceKeyboardHeightToZero) {
+    if (this.props.disableKeyboardAvoiding) {
       return 0;
     }
     if (Platform.OS === 'android' && !this.props.forceGetKeyboardHeight) {
@@ -560,7 +560,7 @@ GiftedChat.defaultProps = {
   onInputTextChanged: null,
   maxInputLength: null,
   forceGetKeyboardHeight: false,
-  forceKeyboardHeightToZero: false,
+  disableKeyboardAvoiding: false,
   inverted: true,
 };
 
@@ -610,7 +610,7 @@ GiftedChat.propTypes = {
   onInputTextChanged: PropTypes.func,
   maxInputLength: PropTypes.number,
   forceGetKeyboardHeight: PropTypes.bool,
-  forceKeyboardHeightToZero: PropTypes.bool,
+  disableKeyboardAvoiding: PropTypes.bool,
   inverted: PropTypes.bool,
   textInputProps: PropTypes.object,
 };

--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -171,6 +171,10 @@ class GiftedChat extends React.Component {
   }
 
   getKeyboardHeight() {
+    // if true, then always force keyboard height to zero
+    if (this.props.forceKeyboardHeightToZero) {
+      return 0;
+    }
     if (Platform.OS === 'android' && !this.props.forceGetKeyboardHeight) {
       // For android: on-screen keyboard resized main container and has own height.
       // @see https://developer.android.com/training/keyboard-input/visibility.html
@@ -556,6 +560,7 @@ GiftedChat.defaultProps = {
   onInputTextChanged: null,
   maxInputLength: null,
   forceGetKeyboardHeight: false,
+  forceKeyboardHeightToZero: false,
   inverted: true,
 };
 
@@ -605,6 +610,7 @@ GiftedChat.propTypes = {
   onInputTextChanged: PropTypes.func,
   maxInputLength: PropTypes.number,
   forceGetKeyboardHeight: PropTypes.bool,
+  forceKeyboardHeightToZero: PropTypes.bool,
   inverted: PropTypes.bool,
   textInputProps: PropTypes.object,
 };


### PR DESCRIPTION
description from README:

* **`disableKeyboardAvoiding`** _(Bool)_ - If true, do not adjust for the onscreen keyboard. Useful if you're managing keyboard avoidance yourself.