### PR TITLE
remove keyboardAppearance as extra prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,6 @@ interface ComposerProps {
   multiline?: boolean;
   textInputStyle?: TextInputProperties["style"];
   textInputAutoFocus?: boolean;
-  keyboardAppearance: TextInputProperties["keyboardAppearance"];
 }
 
 export class Composer extends React.Component<ComposerProps> { }

--- a/src/Composer.js
+++ b/src/Composer.js
@@ -46,7 +46,6 @@ export default class Composer extends React.Component {
         value={this.props.text}
         enablesReturnKeyAutomatically
         underlineColorAndroid="transparent"
-        keyboardAppearance={this.props.keyboardAppearance}
         {...this.props.textInputProps}
       />
     );
@@ -80,7 +79,6 @@ Composer.defaultProps = {
   multiline: true,
   textInputStyle: {},
   textInputAutoFocus: false,
-  keyboardAppearance: 'default',
   onTextChanged: () => {},
   onInputSizeChanged: () => {},
 };
@@ -96,5 +94,4 @@ Composer.propTypes = {
   multiline: PropTypes.bool,
   textInputStyle: TextInput.propTypes.style,
   textInputAutoFocus: PropTypes.bool,
-  keyboardAppearance: PropTypes.string,
 };

--- a/src/__tests__/__snapshots__/Composer.test.js.snap
+++ b/src/__tests__/__snapshots__/Composer.test.js.snap
@@ -7,7 +7,6 @@ exports[`should render <Composer /> and compare with snapshot 1`] = `
   allowFontScaling={true}
   autoFocus={false}
   enablesReturnKeyAutomatically={true}
-  keyboardAppearance="default"
   multiline={true}
   onChange={[Function]}
   onChangeText={[Function]}

--- a/src/__tests__/__snapshots__/InputToolbar.test.js.snap
+++ b/src/__tests__/__snapshots__/InputToolbar.test.js.snap
@@ -99,7 +99,6 @@ exports[`should render <InputToolbar /> and compare with snapshot 1`] = `
       allowFontScaling={true}
       autoFocus={false}
       enablesReturnKeyAutomatically={true}
-      keyboardAppearance="default"
       multiline={true}
       onChange={[Function]}
       onChangeText={[Function]}


### PR DESCRIPTION
There is already a prop called textInputProps where you can change the keyboard appearance, so it's unnecessary to have an extra one. Also this prop is not in the ReadMe, so it seems like it is there in error.