### PR TITLE
Error in FlatList with latest react-native version

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -124,7 +124,7 @@ export default class MessageContainer extends React.PureComponent {
       <View style={styles.container}>
         <FlatList
           ref={(ref) => (this.flatListRef = ref)}
-          keyExtractor={(item) => item._id}
+          keyExtractor={(item) => `${item._id}`}
           enableEmptySections
           automaticallyAdjustContentInsets={false}
           inverted={this.props.inverted}


### PR DESCRIPTION
`keyExtractor` in `FlatList` must now return a string: https://facebook.github.io/react-native/docs/flatlist#keyextractor