### PR TITLE
Justify Bottom Container

### DIFF
--- a/src/Bubble.js
+++ b/src/Bubble.js
@@ -178,7 +178,7 @@ export default class Bubble extends React.PureComponent {
               {this.renderMessageImage()}
               {this.renderMessageVideo()}
               {this.renderMessageText()}
-              <View style={[styles.bottom, this.props.bottomContainerStyle[this.props.position]]}>
+              <View style={[styles[this.props.position].bottom, this.props.bottomContainerStyle[this.props.position]]}>
                 {this.renderUsername()}
                 {this.renderTime()}
                 {this.renderTicks()}
@@ -211,6 +211,10 @@ const styles = {
     containerToPrevious: {
       borderTopLeftRadius: 3,
     },
+    bottom: {
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+    },
   }),
   right: StyleSheet.create({
     container: {
@@ -230,11 +234,11 @@ const styles = {
     containerToPrevious: {
       borderTopRightRadius: 3,
     },
+    bottom: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+    },
   }),
-  bottom: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-  },
   tick: {
     fontSize: 10,
     backgroundColor: Color.backgroundTransparent,

--- a/src/__tests__/__snapshots__/Bubble.test.js.snap
+++ b/src/__tests__/__snapshots__/Bubble.test.js.snap
@@ -50,7 +50,7 @@ exports[`should render <Bubble /> and compare with snapshot 1`] = `
           Array [
             Object {
               "flexDirection": "row",
-              "justifyContent": "flex-end",
+              "justifyContent": "flex-start",
             },
             undefined,
           ]

--- a/src/__tests__/__snapshots__/Message.test.js.snap
+++ b/src/__tests__/__snapshots__/Message.test.js.snap
@@ -103,7 +103,7 @@ exports[`should render <Message /> and compare with snapshot 1`] = `
               Array [
                 Object {
                   "flexDirection": "row",
-                  "justifyContent": "flex-end",
+                  "justifyContent": "flex-start",
                 },
                 undefined,
               ]


### PR DESCRIPTION
## Changed 
Updating the way the bottom container is displayed based off the position of the message.

## Screenshots
Before: 
![screen shot 2018-12-19 at 8 12 32 pm](https://user-images.githubusercontent.com/1743953/50259611-70aa5900-03ca-11e9-9a5a-4c3fcec1ccb3.png)

After: 
![screen shot 2018-12-19 at 8 05 14 pm](https://user-images.githubusercontent.com/1743953/50259374-6fc4f780-03c9-11e9-9b32-594fe3453af1.png)