### PR TITLE
isLoadingEarlier prop bug fix

### DIFF
--- a/src/MessageContainer.js
+++ b/src/MessageContainer.js
@@ -136,6 +136,7 @@ export default class MessageContainer extends React.PureComponent {
           ListFooterComponent={this.renderHeaderWrapper}
           ListHeaderComponent={this.renderFooter}
           {...this.props.listViewProps}
+          isLoadingEarlier={this.props.isLoadingEarlier}
         />
       </View>
     );


### PR DESCRIPTION
loadEarlier component was not re-rendering when the props were changing because FlatList only re-render when the props changes but in the current code, the props were same, so had to pass the isLoadingEarlier={this.props.isLoading} to FlatList of Message Container.