### PR TITLE
Change react-native-video to a peer dependency with any version required

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,12 +71,12 @@
     "react-native-communications": "2.2.1",
     "react-native-lightbox": "^0.7.0",
     "react-native-parsed-text": "^0.0.20",
-    "react-native-video": "^3.2.1",
     "uuid": "3.3.0"
   },
   "peerDependencies": {
     "prop-types": "*",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-video": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "prop-types": "*",
     "react": "*",
     "react-native": "*",
-    "react-native-video": "*"
+    "react-native-video": "*",
+    "react-native-video-controls": "*" 
   }
 }

--- a/src/MessageVideo.js
+++ b/src/MessageVideo.js
@@ -20,9 +20,9 @@ export default function MessageVideo({
         source={{ uri: currentMessage.video }}
         style={videoStyle}
         controls
-        onBuffer={this.onBuffer}
-        onLoadStart={this.onLoadStart}
-        onLoad={this.onLoad}
+        //onBuffer={this.onBuffer}
+        //onLoadStart={this.onLoadStart}
+        //onLoad={this.onLoad}
         paused
         resizeMode={this.props.resizeMode}
       />

--- a/src/MessageVideo.js
+++ b/src/MessageVideo.js
@@ -23,6 +23,7 @@ export default function MessageVideo({
         onBuffer={this.onBuffer}
         onLoadStart={this.onLoadStart}
         onLoad={this.onLoad}
+        resizeMode={this.props.resizeMode}
       />
     </View>
   );
@@ -43,9 +44,10 @@ MessageVideo.defaultProps = {
     height: 100,
     borderRadius: 13,
     margin: 3,
-    resizeMode: 'cover',
+
   },
   videoProps: {},
+  resizeMode: "cover",
 };
 
 MessageVideo.propTypes = {
@@ -53,4 +55,5 @@ MessageVideo.propTypes = {
   containerStyle: ViewPropTypes.style,
   videoStyle: ViewPropTypes.style,
   videoProps: PropTypes.object,
+  resizeMode: PropTypes.string,
 };

--- a/src/MessageVideo.js
+++ b/src/MessageVideo.js
@@ -19,10 +19,11 @@ export default function MessageVideo({
         ref={(r) => { this.player = r; }}
         source={{ uri: currentMessage.video }}
         style={videoStyle}
-        resizeMode="cover"
+        controls
         onBuffer={this.onBuffer}
         onLoadStart={this.onLoadStart}
         onLoad={this.onLoad}
+        paused
         resizeMode={this.props.resizeMode}
       />
     </View>

--- a/src/MessageVideo.js
+++ b/src/MessageVideo.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, View, ViewPropTypes } from 'react-native';
-import Video from 'react-native-video';
+import Video from 'react-native-video-controls';
 
 
 export default function MessageVideo({


### PR DESCRIPTION
Including react-native-video as a dependancy at ^3.2.1 caused a conflict with our existing usage of react-native-video. Error was: "Tried to register two views with the same name RCTVideo".

Changing react-native-video to a peer dependency resolves this issue.

I've also confirmed that the video feature works fine with the newest version of react-native-video.

We could alternatively set it as a peer dependency with version 3.x as well?