### PR TITLE
Fixes failed prop type warning for resizeMode

### DIFF
--- a/src/MessageVideo.js
+++ b/src/MessageVideo.js
@@ -43,7 +43,6 @@ MessageVideo.defaultProps = {
     height: 100,
     borderRadius: 13,
     margin: 3,
-    resizeMode: 'cover',
   },
   videoProps: {},
 };


### PR DESCRIPTION
## Changes

- Removes resizeMode from `videoStyle` props as this causes `Warning: Failed prop type: Invalid props.style key resizeMode`