### PR TITLE
 Updating the code to fix MinComposerHeight is not respecting props in some instances.

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -55,7 +55,7 @@ class GiftedChat extends React.Component {
 
     this.state = {
       isInitialized: false, // initialization will calculate maxHeight before rendering the chat
-      composerHeight: MIN_COMPOSER_HEIGHT,
+      composerHeight: this.props.minComposerHeight,
       messagesContainerHeight: null,
       typingDisabled: false,
     };
@@ -222,7 +222,7 @@ class GiftedChat extends React.Component {
       : this.props.minInputToolbarHeight;
   }
   calculateInputToolbarHeight(composerHeight) {
-    return composerHeight + (this.getMinInputToolbarHeight() - MIN_COMPOSER_HEIGHT);
+    return composerHeight + (this.getMinInputToolbarHeight() - this.props.minComposerHeight);
   }
 
   /**
@@ -357,7 +357,7 @@ class GiftedChat extends React.Component {
       this.textInput.clear();
     }
     this.notifyInputTextReset();
-    const newComposerHeight = MIN_COMPOSER_HEIGHT;
+    const newComposerHeight = this.props.minComposerHeight;
     const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard(newComposerHeight);
     this.setState({
       text: this.getTextFromProp(''),
@@ -412,7 +412,7 @@ class GiftedChat extends React.Component {
     }
     this.notifyInputTextReset();
     this.setMaxHeight(layout.height);
-    const newComposerHeight = MIN_COMPOSER_HEIGHT;
+    const newComposerHeight = this.props.minComposerHeight;
     const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard(newComposerHeight);
     this.setState({
       isInitialized: true,
@@ -440,7 +440,7 @@ class GiftedChat extends React.Component {
     const inputToolbarProps = {
       ...this.props,
       text: this.getTextFromProp(this.state.text),
-      composerHeight: Math.max(MIN_COMPOSER_HEIGHT, this.state.composerHeight),
+      composerHeight: Math.max(this.props.minComposerHeight, this.state.composerHeight),
       onSend: this.onSend,
       onInputSizeChanged: this.onInputSizeChanged,
       onTextChanged: this.onInputTextChanged,


### PR DESCRIPTION
## Issue
minComposerHeight is hardcoded to use constant instead of props in few instances. Due to this minimumToolbarHeight will give incorrect result thus making UI look inconsistent.


## Solution
updating the code to use the props in all instances.

## Testing
if we add minComposerHeight prop to the giftedChatComponent, there is a bottomOffset on keyboard open as the minInputToolbarHeight is returning incorrect value based on the hardcoded minComposerHeight.
