### PR TITLE
Add initialText prop

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -414,9 +414,10 @@ class GiftedChat extends React.Component {
     this.setMaxHeight(layout.height);
     const newComposerHeight = this.props.minComposerHeight;
     const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard(newComposerHeight);
+    const initialText = this.props.initialText || '';
     this.setState({
       isInitialized: true,
-      text: this.getTextFromProp(''),
+      text: this.getTextFromProp(initialText),
       composerHeight: newComposerHeight,
       messagesContainerHeight: this.prepareMessagesContainerHeight(newMessagesContainerHeight),
     });
@@ -572,6 +573,7 @@ GiftedChat.defaultProps = {
 GiftedChat.propTypes = {
   messages: PropTypes.arrayOf(PropTypes.object),
   text: PropTypes.string,
+  initialText: PropTypes.string,
   placeholder: PropTypes.string,
   messageIdGenerator: PropTypes.func,
   user: PropTypes.object,


### PR DESCRIPTION
Add `initialText` prop to `GiftedChat` - this gives ability to initialise chat with pre-filled value in case when you don't use `text` prop. Useful for caching input value when you re-enter chat.