### PR TITLE
Add clearTextInput argument to resetInputToolbar

### DIFF
--- a/src/GiftedChat.js
+++ b/src/GiftedChat.js
@@ -352,15 +352,18 @@ class GiftedChat extends React.Component {
     }
   }
 
-  resetInputToolbar() {
-    if (this.textInput) {
-      this.textInput.clear();
+  resetInputToolbar(clearTextInput = true) {
+    if (clearTextInput) {
+      if (this.textInput) {
+        this.textInput.clear();
+      }
+      this.notifyInputTextReset();
     }
-    this.notifyInputTextReset();
+
     const newComposerHeight = this.props.minComposerHeight;
     const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard(newComposerHeight);
     this.setState({
-      text: this.getTextFromProp(''),
+      text: this.getTextFromProp(clearTextInput ? '' : this.state.text),
       composerHeight: newComposerHeight,
       messagesContainerHeight: this.prepareMessagesContainerHeight(newMessagesContainerHeight),
     });


### PR DESCRIPTION
In my app I call resetInputToolbar to recalculate InputToolBar and MessageContainer size, but I don't wont to clear TextInput, so this change helped me. Maybe this will be useful for someone else.