### PR TITLE
Fix chat not getting re-rendered if deleting previous message

### DIFF
--- a/src/Message.js
+++ b/src/Message.js
@@ -40,7 +40,6 @@ export default class Message extends React.Component {
     const { nextMessage, previousMessage } = this.props;
     const nextPropsMessage = nextProps.nextMessage;
     const nextPropsPreviousMessage = nextProps.previousMessage;
-
     return (
       next.sent !== current.sent ||
       next.received !== current.received ||

--- a/src/Message.js
+++ b/src/Message.js
@@ -37,18 +37,20 @@ export default class Message extends React.Component {
   shouldComponentUpdate(nextProps) {
     const next = nextProps.currentMessage;
     const current = this.props.currentMessage;
-    const { nextMessage } = this.props;
+    const { nextMessage, previousMessage } = this.props;
     const nextPropsMessage = nextProps.nextMessage;
+    const prevPropsMessage = nextProps.previousMessage;
+
     return (
-      next.sent !== current.sent ||
+      next.send !== current.send ||
       next.received !== current.received ||
       next.pending !== current.pending ||
       next.createdAt !== current.createdAt ||
       next.text !== current.text ||
       next.image !== current.image ||
       next.video !== current.video ||
-      next.audio !== current.audio ||
-      nextMessage !== nextPropsMessage
+      nextMessage !== nextPropsMessage ||
+      prevPropsMessage !== previousMessage
     );
   }
 

--- a/src/Message.js
+++ b/src/Message.js
@@ -39,21 +39,22 @@ export default class Message extends React.Component {
     const current = this.props.currentMessage;
     const { nextMessage, previousMessage } = this.props;
     const nextPropsMessage = nextProps.nextMessage;
-    const prevPropsMessage = nextProps.previousMessage;
+    const nextPropsPreviousMessage = nextProps.previousMessage;
 
     return (
-      next.send !== current.send ||
+      next.sent !== current.sent ||
       next.received !== current.received ||
       next.pending !== current.pending ||
       next.createdAt !== current.createdAt ||
       next.text !== current.text ||
       next.image !== current.image ||
       next.video !== current.video ||
+      next.audio !== current.audio ||
       nextMessage !== nextPropsMessage ||
-      prevPropsMessage !== previousMessage
+      nextPropsPreviousMessage !== previousMessage
     );
   }
-
+  
   getInnerComponentProps = () => {
     const { containerStyle, ...props } = this.props;
     return {

--- a/src/Message.js
+++ b/src/Message.js
@@ -53,7 +53,7 @@ export default class Message extends React.Component {
       nextPropsPreviousMessage !== previousMessage
     );
   }
-  
+
   getInnerComponentProps = () => {
     const { containerStyle, ...props } = this.props;
     return {


### PR DESCRIPTION
If user deletes a message in history the previous message isn't getting re-rendered.
For instance if remote user writes 3 messages and only first message shows avatar, if you delete the message with avatar avatar isn't shown on the screen any more. This pull request fixes the issue by comparing current instance of previousMessage vs nextProps previousMessage 