### PR TITLE
Add styles to render in user.avatar

### DIFF
--- a/src/GiftedAvatar.js
+++ b/src/GiftedAvatar.js
@@ -33,7 +33,7 @@ export default class GiftedAvatar extends React.Component {
 
   renderAvatar() {
     if (typeof this.props.user.avatar === 'function') {
-      return this.props.user.avatar();
+      return this.props.user.avatar([styles.avatarStyle, this.props.avatarStyle]);
     } else if (typeof this.props.user.avatar === 'string') {
       return <Image source={{ uri: this.props.user.avatar }} style={[styles.avatarStyle, this.props.avatarStyle]} />;
     } else if (typeof this.props.user.avatar === 'number') {


### PR DESCRIPTION
I want to use `<CachedImage />` component instead of `<Image />` to use cached images on user device. I've noticed that `avatar` user props could be a function. 

Usage example:
```
   ...(m.author.profilePhotoUrl && {
      avatar: style => {
        return (
          <CachedImage
            source={{ uri: m.author.profilePhotoUrl }}
            style={style}
          />
        )
      }
    })
```