### PR TITLE
Adding support to SafeAreaView for iphoneX

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@expo/react-native-action-sheet": "^2.0.1",
     "moment": "^2.19.0",
     "react-native-communications": "2.2.1",
+    "react-native-iphone-x-helper": "^1.2.0",
     "react-native-lightbox": "^0.7.0",
     "react-native-parsed-text": "^0.0.20",
     "react-native-video": "^3.2.1",

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import React, { RefObject } from 'react'
-import { Animated, Platform, StyleSheet, View, ViewStyle } from 'react-native'
+import { Animated, Platform, StyleSheet, View, ViewStyle, SafeAreaView } from 'react-native'
 
 import ActionSheet from '@expo/react-native-action-sheet'
 import moment from 'moment'
 import uuid from 'uuid'
+import { isIphoneX } from 'react-native-iphone-x-helper'
 
 import * as utils from './utils'
 import Actions from './Actions'
@@ -502,12 +503,19 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
     return value
   }
 
+  safeAreaIphoneX = (bottomOffset: number) => {
+    if(isIphoneX()) {
+      return bottomOffset === this._bottomOffset ? 33 : bottomOffset;
+    }
+    return bottomOffset;
+  }
+
   onKeyboardWillShow = (e: any) => {
     this.setIsTypingDisabled(true)
     this.setKeyboardHeight(
       e.endCoordinates ? e.endCoordinates.height : e.end.height,
     )
-    this.setBottomOffset(this.props.bottomOffset!)
+    this.setBottomOffset(this.safeAreaIphoneX(this.props.bottomOffset!))
     const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
     if (this.props.isAnimated === true) {
       Animated.timing(this.state.messagesContainerHeight!, {
@@ -751,14 +759,16 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
   render() {
     if (this.state.isInitialized === true) {
       return (
-        <GiftedActionSheet
-          ref={(component: any) => (this._actionSheetRef = component)}
-        >
-          <View style={styles.container} onLayout={this.onMainViewLayout}>
-            {this.renderMessages()}
-            {this.renderInputToolbar()}
-          </View>
-        </GiftedActionSheet>
+        <SafeAreaView style={styles.safeArea}>
+          <GiftedActionSheet
+            ref={(component: any) => (this._actionSheetRef = component)}
+          >
+            <View style={styles.container} onLayout={this.onMainViewLayout}>
+              {this.renderMessages()}
+              {this.renderInputToolbar()}
+            </View>
+          </GiftedActionSheet>
+        </SafeAreaView>
       )
     }
     return (
@@ -773,6 +783,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  safeArea: {
+    flex: 1
+  }
 })
 
 export {


### PR DESCRIPTION
#### Description: 
As I mentioned in this issue: https://github.com/FaridSafi/react-native-gifted-chat/issues/1217. When a safeAreaView is added an extra space is added between the keyboard and the input.
This PR fixes it.