### PR TITLE
Do not setState for text if textProp is undefined

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -384,7 +384,7 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
 
   setTextFromProp(textProp?: string) {
     // Text prop takes precedence over state.
-    if (!textProp && textProp !== this.state.text) {
+    if (textProp !== undefined && textProp !== this.state.text) {
       this.setState({ text: textProp })
     }
   }


### PR DESCRIPTION
Fixes https://github.com/FaridSafi/react-native-gifted-chat/issues/1219

Every time props update (new messages, etc), the text input is cleared. This was caused by a bug during the typescript migration. It should not `setState` if `textProp` is undefined. 


Original GiftedChat.js file - https://github.com/FaridSafi/react-native-gifted-chat/commit/f2476298b983610e1af80d96c3d24328bb926f9d#diff-a2356064fe377d125c72f41f52d4dad5L141

```
  setTextFromProp(textProp) {
    // Text prop takes precedence over state.
    if (textProp !== undefined && textProp !== this.state.text) {
      this.setState({ text: textProp });
    }
  }

```
Migrated tsx file (with bug) - https://github.com/FaridSafi/react-native-gifted-chat/commit/f2476298b983610e1af80d96c3d24328bb926f9d#diff-81fff307db236f330955389dbb02155eR385

```
  setTextFromProp(textProp?: string) {
    // Text prop takes precedence over state.
    if (!textProp && textProp !== this.state.text) {
      this.setState({ text: textProp })
    }
  }
```
