### PR TITLE
missing object user in message

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -257,7 +257,7 @@ export default class MessageContainer extends React.PureComponent<
       if (this.props.renderMessage) {
         return this.props.renderMessage(messageProps)
       }
-      return <Message {...messageProps} />
+      return <Message {...messageProps} {...user} />
     }
     return null
   }


### PR DESCRIPTION
Object user is required in order to render ticks and to fix showUserAvatar prop.