### PR TITLE
fix duplicate day rendering

### DIFF
--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -84,8 +84,8 @@ export default class Message extends React.Component<MessageProps> {
   shouldComponentUpdate(nextProps: MessageProps) {
     const next = nextProps.currentMessage!
     const current = this.props.currentMessage!
-    const { nextMessage } = this.props
-    const nextPropsMessage = nextProps.nextMessage
+    const { previousMessage } = this.props;
+    const nextPropsPreviousMessage = nextProps.previousMessage;
     return (
       next.sent !== current.sent ||
       next.received !== current.received ||
@@ -95,7 +95,7 @@ export default class Message extends React.Component<MessageProps> {
       next.image !== current.image ||
       next.video !== current.video ||
       next.audio !== current.audio ||
-      nextMessage !== nextPropsMessage
+      previousMessage !== nextPropsPreviousMessage
     )
   }
 


### PR DESCRIPTION
Same day renders several times when loading earlier messages. Аnimation below describes the problem.

### Actual behavior
![wrong](https://user-images.githubusercontent.com/14232660/58812163-eb3dfc80-8629-11e9-8800-08c8dbdca28b.gif)

### Expected behavior
![correct](https://user-images.githubusercontent.com/14232660/58812162-eb3dfc80-8629-11e9-8f50-7a2c045aa572.gif)

### Code to reproduce

```javascript
import React, {Component} from 'react';
import {View} from 'react-native';
import {GiftedChat} from 'react-native-gifted-chat';
import moment from 'moment';

export default class ChatApp extends Component {

    constructor() {
        super();

        // Generating some message history.
        this.data = [];
        let createdAt = moment()

        for (let i = 0; i < 100; i++) {
            // We need four message per one day.
            if (!(i / 2 % 2)) {
                createdAt = createdAt.clone().subtract(1, 'day')
            }

            this.data.push({
                _id: i,
                text: i % 2 ? 'Namaste!' : 'Hey!',
                createdAt,
                user: {
                    _id: i % 2 ? 1 : 2,
                    name: i % 2 ? 'Me' : 'You'
                }
            })            
        }

        this.state = {
            messages: this.data.splice(0, 2)
        }
    }

    loadEarlier() {
        // Get two more messages.
        this.setState({
            messages: GiftedChat.prepend(this.state.messages, this.data.splice(0, 2))
        })
    }

    render() {
        return (
            <View style={{flex: 1, backgroundColor: 'white'}}>
                <GiftedChat
                    messages={this.state.messages}
                    loadEarlier={true}
                    onLoadEarlier={() => this.loadEarlier()}
                    renderUsernameOnMessage={true}
                    user={{_id: 1}}
                    renderAvatar={null}
                    placeholder='message'
                    dateFormat={'LL'}
                    inverted={true}
                />
            </View>
        )
    }
}
```