### PR TITLE
Typing improvements

### DIFF
--- a/src/Actions.tsx
+++ b/src/Actions.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
   ViewPropTypes,
+  StyleProp,
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -15,9 +16,9 @@ interface ActionsProps {
   options?: { [key: string]: any }
   optionTintColor?: string
   icon?: () => ReactNode
-  wrapperStyle?: ViewStyle
-  iconTextStyle?: TextStyle
-  containerStyle?: ViewStyle
+  wrapperStyle?: StyleProp<ViewStyle>
+  iconTextStyle?: StyleProp<TextStyle>
+  containerStyle?: StyleProp<ViewStyle>
   onPressActionButton?(): void
 }
 

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -42,20 +42,20 @@ const styles = {
   }),
 }
 
-interface AvatarProps {
-  currentMessage?: IMessage
-  previousMessage?: IMessage
-  nextMessage?: IMessage
+interface AvatarProps<TMessage extends IMessage> {
+  currentMessage?: TMessage
+  previousMessage?: TMessage
+  nextMessage?: TMessage
   position: 'left' | 'right'
   renderAvatarOnTop?: boolean
   showAvatarForEveryMessage?: boolean
   imageStyle?: LeftRightStyle<ImageStyle>
   containerStyle?: LeftRightStyle<ViewStyle>
-  renderAvatar?(props: Omit<AvatarProps, 'renderAvatar'>): ReactNode
+  renderAvatar?(props: Omit<AvatarProps<TMessage>, 'renderAvatar'>): ReactNode
   onPressAvatar?(user: User): void
 }
 
-export default class Avatar extends React.Component<AvatarProps> {
+export default class Avatar<TMessage extends IMessage = IMessage> extends React.Component<AvatarProps<TMessage>> {
   static defaultProps = {
     renderAvatarOnTop: false,
     showAvatarForEveryMessage: false,

--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -22,7 +22,7 @@ import Time from './Time'
 import Color from './Color'
 
 import { isSameUser, isSameDay } from './utils'
-import { User, IMessage, LeftRightStyle, Reply } from './types'
+import { User, IMessage, LeftRightStyle, Reply, Omit } from './types'
 
 const styles = {
   left: StyleSheet.create({
@@ -97,6 +97,18 @@ const styles = {
 
 const DEFAULT_OPTION_TITLES = ['Copy Text', 'Cancel']
 
+export type RenderMessageImageProps<TMessage extends IMessage> =
+  Omit<BubbleProps<TMessage>, 'containerStyle' | 'wrapperStyle'> &
+  MessageImage['props'];
+
+export type RenderMessageVideoProps<TMessage extends IMessage> =
+  Omit<BubbleProps<TMessage>, 'containerStyle' | 'wrapperStyle'> &
+  MessageVideo['props']
+
+export type RenderMessageTextProps<TMessage extends IMessage> =
+  Omit<BubbleProps<TMessage>, 'containerStyle' | 'wrapperStyle'> &
+  MessageText['props']
+
 interface BubbleProps<TMessage extends IMessage> {
   user?: User
   touchableProps?: object
@@ -116,9 +128,9 @@ interface BubbleProps<TMessage extends IMessage> {
   usernameStyle?: LeftRightStyle<ViewStyle>
   onLongPress?(context?: any, message?: any): void
   onQuickReply?(replies: Reply[]): void
-  renderMessageImage?(messageImageProps: MessageImage['props']): React.ReactNode
-  renderMessageVideo?(messageVideoProps: MessageVideo['props']): React.ReactNode
-  renderMessageText?(messageTextProps: MessageText['props']): React.ReactNode
+  renderMessageImage?(props: RenderMessageImageProps<TMessage>): React.ReactNode
+  renderMessageVideo?(props: RenderMessageVideoProps<TMessage>): React.ReactNode
+  renderMessageText?(props: RenderMessageTextProps<TMessage>): React.ReactNode
   renderCustomView?(bubbleProps: BubbleProps<TMessage>): React.ReactNode
   renderTime?(timeProps: Time['props']): React.ReactNode
   renderTicks?(currentMessage: TMessage): React.ReactNode

--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewPropTypes,
+  StyleProp,
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -109,7 +110,7 @@ interface BubbleProps<TMessage extends IMessage> {
   wrapperStyle?: LeftRightStyle<ViewStyle>
   textStyle?: LeftRightStyle<TextStyle>
   bottomContainerStyle?: LeftRightStyle<ViewStyle>
-  tickStyle?: TextStyle
+  tickStyle?: StyleProp<TextStyle>
   containerToNextStyle?: LeftRightStyle<ViewStyle>
   containerToPreviousStyle?: LeftRightStyle<ViewStyle>
   usernameStyle?: LeftRightStyle<ViewStyle>

--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -96,7 +96,7 @@ const styles = {
 
 const DEFAULT_OPTION_TITLES = ['Copy Text', 'Cancel']
 
-interface BubbleProps<TMessage extends IMessage = IMessage> {
+interface BubbleProps<TMessage extends IMessage> {
   user?: User
   touchableProps?: object
   renderUsernameOnMessage?: boolean
@@ -118,7 +118,7 @@ interface BubbleProps<TMessage extends IMessage = IMessage> {
   renderMessageImage?(messageImageProps: MessageImage['props']): React.ReactNode
   renderMessageVideo?(messageVideoProps: MessageVideo['props']): React.ReactNode
   renderMessageText?(messageTextProps: MessageText['props']): React.ReactNode
-  renderCustomView?(bubbleProps: BubbleProps): React.ReactNode
+  renderCustomView?(bubbleProps: BubbleProps<TMessage>): React.ReactNode
   renderTime?(timeProps: Time['props']): React.ReactNode
   renderTicks?(currentMessage: TMessage): React.ReactNode
   renderUsername?(): React.ReactNode
@@ -128,7 +128,7 @@ interface BubbleProps<TMessage extends IMessage = IMessage> {
   isSameUser?(currentMessage: TMessage, nextMessage: TMessage): boolean
 }
 
-export default class Bubble extends React.Component<BubbleProps> {
+export default class Bubble<TMessage extends IMessage = IMessage> extends React.Component<BubbleProps<TMessage>> {
   static contextTypes = {
     actionSheet: PropTypes.func,
   }

--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
   },
 })
 
-interface DayProps<TMessage extends IMessage = IMessage> {
+interface DayProps<TMessage extends IMessage> {
   currentMessage?: TMessage
   nextMessage?: TMessage
   previousMessage?: TMessage
@@ -42,7 +42,7 @@ interface DayProps<TMessage extends IMessage = IMessage> {
   inverted?: boolean
 }
 
-export default class Day extends PureComponent<DayProps> {
+export default class Day<TMessage extends IMessage = IMessage> extends PureComponent<DayProps<TMessage>> {
   static contextTypes = {
     getLocale: PropTypes.func,
   }

--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   View,
   ViewPropTypes,
+  StyleProp,
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -35,9 +36,9 @@ interface DayProps<TMessage extends IMessage> {
   currentMessage?: TMessage
   nextMessage?: TMessage
   previousMessage?: TMessage
-  containerStyle?: ViewStyle
-  wrapperStyle?: ViewStyle
-  textStyle?: TextStyle
+  containerStyle?: StyleProp<ViewStyle>
+  wrapperStyle?: StyleProp<ViewStyle>
+  textStyle?: StyleProp<TextStyle>
   dateFormat?: string
   inverted?: boolean
 }

--- a/src/GiftedAvatar.tsx
+++ b/src/GiftedAvatar.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
   StyleSheet,
+  StyleProp,
   ImageStyle,
   TextStyle,
 } from 'react-native'
@@ -43,8 +44,8 @@ const styles = StyleSheet.create({
 
 interface GiftedAvatarProps {
   user?: User
-  avatarStyle?: ImageStyle
-  textStyle?: TextStyle
+  avatarStyle?: StyleProp<ImageStyle>
+  textStyle?: StyleProp<TextStyle>
   onPress?(props: any): void
 }
 

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -167,7 +167,7 @@ interface GiftedChatState {
   text?: string
 }
 
-class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
+class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<GiftedChatProps<TMessage>, GiftedChatState> {
   static childContextTypes = {
     actionSheet: PropTypes.func,
     getLocale: PropTypes.func,
@@ -291,9 +291,9 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
     alignTop: PropTypes.bool,
   }
 
-  static append(
-    currentMessages: IMessage[] = [],
-    messages: IMessage[],
+  static append<TMessage extends IMessage>(
+    currentMessages: TMessage[] = [],
+    messages: TMessage[],
     inverted = true,
   ) {
     if (!Array.isArray(messages)) {
@@ -304,9 +304,9 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
       : currentMessages.concat(messages)
   }
 
-  static prepend(
-    currentMessages: IMessage[] = [],
-    messages: IMessage[],
+  static prepend<TMessage extends IMessage>(
+    currentMessages: TMessage[] = [],
+    messages: TMessage[],
     inverted = true,
   ) {
     if (!Array.isArray(messages)) {
@@ -323,7 +323,7 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
   _maxHeight?: number = undefined
   _isFirstLayout: boolean = true
   _locale: string = 'en'
-  _messages: IMessage[] = []
+  _messages: TMessage[] = []
   invertibleScrollViewProps: any = undefined
   _actionSheetRef: any = undefined
 
@@ -338,7 +338,7 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
     text: undefined,
   }
 
-  constructor(props: GiftedChatProps) {
+  constructor(props: GiftedChatProps<TMessage>) {
     super(props)
 
     this.invertibleScrollViewProps = {
@@ -370,7 +370,7 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
     this.setIsMounted(false)
   }
 
-  componentWillReceiveProps(nextProps: GiftedChatProps = {}) {
+  componentWillReceiveProps(nextProps: GiftedChatProps<TMessage> = {}) {
     const { messages, text } = nextProps
     this.setMessages(messages || [])
     this.setTextFromProp(text)
@@ -407,7 +407,7 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
     return this.props.text
   }
 
-  setMessages(messages: IMessage[]) {
+  setMessages(messages: TMessage[]) {
     this._messages = messages
   }
 
@@ -595,11 +595,11 @@ class GiftedChat extends React.Component<GiftedChatProps, GiftedChatState> {
     )
   }
 
-  onSend = (messages: IMessage[] = [], shouldResetInputToolbar = false) => {
+  onSend = (messages: TMessage[] = [], shouldResetInputToolbar = false) => {
     if (!Array.isArray(messages)) {
       messages = [messages]
     }
-    const newMessages: IMessage[] = messages.map(message => {
+    const newMessages: TMessage[] = messages.map(message => {
       return {
         ...message,
         user: this.props.user!,

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -5,6 +5,7 @@ import {
   Platform,
   StyleSheet,
   View,
+  StyleProp,
   ViewStyle,
   SafeAreaView,
 } from 'react-native'
@@ -93,7 +94,7 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* Force send button */
   alwaysShowSend?: boolean
   /* Image style */
-  imageStyle?: ViewStyle
+  imageStyle?: StyleProp<ViewStyle>
   /* This can be used to pass any data which needs to be re-rendered */
   extraData?: any
   /* composer min Height */

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -795,6 +795,8 @@ const styles = StyleSheet.create({
   },
 })
 
+export * from './types';
+
 export {
   GiftedChat,
   Actions,

--- a/src/InputToolbar.tsx
+++ b/src/InputToolbar.tsx
@@ -6,6 +6,7 @@ import {
   Keyboard,
   ViewPropTypes,
   EmitterSubscription,
+  StyleProp,
   ViewStyle,
 } from 'react-native'
 
@@ -35,9 +36,9 @@ const styles = StyleSheet.create({
 interface InputToolbarProps {
   options?: { [key: string]: any }
   optionTintColor?: string
-  containerStyle?: ViewStyle
-  primaryStyle?: ViewStyle
-  accessoryStyle?: ViewStyle
+  containerStyle?: StyleProp<ViewStyle>
+  primaryStyle?: StyleProp<ViewStyle>
+  accessoryStyle?: StyleProp<ViewStyle>
   renderAccessory?(props: InputToolbarProps): React.ReactNode
   renderActions?(props: Actions['props']): React.ReactNode
   renderSend?(props: Send['props']): React.ReactNode

--- a/src/LoadEarlier.tsx
+++ b/src/LoadEarlier.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   View,
   ViewPropTypes,
+  StyleProp,
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -44,10 +45,10 @@ const styles = StyleSheet.create({
 interface LoadEarlierProps {
   isLoadingEarlier?: boolean
   label?: string
-  containerStyle?: ViewStyle
-  wrapperStyle?: ViewStyle
-  textStyle?: TextStyle
-  activityIndicatorStyle?: ViewStyle
+  containerStyle?: StyleProp<ViewStyle>
+  wrapperStyle?: StyleProp<ViewStyle>
+  textStyle?: StyleProp<TextStyle>
+  activityIndicatorStyle?: StyleProp<ViewStyle>
   activityIndicatorColor?: string
   activityIndicatorSize?: number | 'small' | 'large'
   onLoadEarlier?(): void

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -31,7 +31,7 @@ const styles = {
   }),
 }
 
-interface MessageProps<TMessage extends IMessage = IMessage> {
+interface MessageProps<TMessage extends IMessage> {
   key: any
   showUserAvatar?: boolean
   position: 'left' | 'right'
@@ -47,7 +47,7 @@ interface MessageProps<TMessage extends IMessage = IMessage> {
   renderAvatar?(props: Avatar['props']): React.ReactNode
 }
 
-export default class Message extends React.Component<MessageProps> {
+export default class Message<TMessage extends IMessage = IMessage> extends React.Component<MessageProps<TMessage>> {
   static defaultProps = {
     renderAvatar: undefined,
     renderBubble: null,
@@ -81,7 +81,7 @@ export default class Message extends React.Component<MessageProps> {
     }),
   }
 
-  shouldComponentUpdate(nextProps: MessageProps) {
+  shouldComponentUpdate(nextProps: MessageProps<TMessage>) {
     const next = nextProps.currentMessage!
     const current = this.props.currentMessage!
     const { previousMessage, nextMessage } = this.props;

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
   },
 })
 
-interface MessageContainerProps<TMessage extends IMessage = IMessage> {
+interface MessageContainerProps<TMessage extends IMessage> {
   messages?: TMessage[]
   user?: User
   listViewProps: Partial<ListViewProps>
@@ -66,15 +66,15 @@ interface MessageContainerProps<TMessage extends IMessage = IMessage> {
   invertibleScrollViewProps?: any
   extraData?: any
   scrollToBottomOffset?: number
-  renderFooter?(props: MessageContainerProps): React.ReactNode
+  renderFooter?(props: MessageContainerProps<TMessage>): React.ReactNode
   renderMessage?(props: Message['props']): React.ReactNode
   renderLoadEarlier?(props: LoadEarlier['props']): React.ReactNode
   scrollToBottomComponent?(): React.ReactNode
   onLoadEarlier?(): void
 }
 
-export default class MessageContainer extends React.PureComponent<
-  MessageContainerProps,
+export default class MessageContainer<TMessage extends IMessage = IMessage> extends React.PureComponent<
+  MessageContainerProps<TMessage>,
   { showScrollBottom: boolean }
 > {
   static defaultProps = {
@@ -115,7 +115,7 @@ export default class MessageContainer extends React.PureComponent<
     showScrollBottom: false,
   }
 
-  flatListRef?: RefObject<FlatList<IMessage>> = React.createRef()
+  flatListRef?: RefObject<FlatList<TMessage>> = React.createRef()
 
   componentDidMount() {
     if (this.props.messages && this.props.messages.length === 0) {
@@ -127,7 +127,7 @@ export default class MessageContainer extends React.PureComponent<
     this.detachKeyboardListeners()
   }
 
-  componentWillReceiveProps(nextProps: MessageContainerProps) {
+  componentWillReceiveProps(nextProps: MessageContainerProps<TMessage>) {
     if (
       this.props.messages &&
       this.props.messages.length === 0 &&
@@ -222,7 +222,7 @@ export default class MessageContainer extends React.PureComponent<
     }
   }
 
-  renderRow = ({ item, index }: ListRenderItemInfo<IMessage>) => {
+  renderRow = ({ item, index }: ListRenderItemInfo<TMessage>) => {
     if (!item._id && item._id !== 0) {
       console.warn(
         'GiftedChat: `_id` is missing for message',
@@ -288,7 +288,7 @@ export default class MessageContainer extends React.PureComponent<
     )
   }
 
-  keyExtractor = (item: IMessage) => `${item._id}`
+  keyExtractor = (item: TMessage) => `${item._id}`
 
   render() {
     if (

--- a/src/MessageImage.tsx
+++ b/src/MessageImage.tsx
@@ -7,6 +7,7 @@ import {
   ViewPropTypes,
   ImageProps,
   ViewStyle,
+  StyleProp,
   ImageStyle,
 } from 'react-native'
 // @ts-ignore
@@ -30,8 +31,8 @@ const styles = StyleSheet.create({
 
 interface MessageImageProps<TMessage extends IMessage> {
   currentMessage?: TMessage
-  containerStyle?: ViewStyle
-  imageStyle?: ImageStyle
+  containerStyle?: StyleProp<ViewStyle>
+  imageStyle?: StyleProp<ImageStyle>
   imageProps?: Partial<ImageProps>
   lightboxProps?: object
 }

--- a/src/MessageImage.tsx
+++ b/src/MessageImage.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
   },
 })
 
-interface MessageImageProps<TMessage extends IMessage = IMessage> {
+interface MessageImageProps<TMessage extends IMessage> {
   currentMessage?: TMessage
   containerStyle?: ViewStyle
   imageStyle?: ImageStyle
@@ -36,7 +36,7 @@ interface MessageImageProps<TMessage extends IMessage = IMessage> {
   lightboxProps?: object
 }
 
-export default class MessageImage extends Component<MessageImageProps> {
+export default class MessageImage<TMessage extends IMessage = IMessage> extends Component<MessageImageProps<TMessage>> {
   static defaultProps = {
     currentMessage: {
       image: null,

--- a/src/MessageText.tsx
+++ b/src/MessageText.tsx
@@ -6,6 +6,7 @@ import {
   View,
   ViewPropTypes,
   TextProps,
+  StyleProp,
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -58,7 +59,7 @@ interface MessageTextProps<TMessage extends IMessage> {
   textStyle?: LeftRightStyle<TextStyle>
   linkStyle?: LeftRightStyle<TextStyle>
   textProps?: TextProps
-  customTextStyle?: TextStyle
+  customTextStyle?: StyleProp<TextStyle>
   parsePatterns?(linkStyle: TextStyle): any
 }
 

--- a/src/MessageText.tsx
+++ b/src/MessageText.tsx
@@ -51,7 +51,7 @@ const styles = {
   }),
 }
 
-interface MessageTextProps<TMessage extends IMessage = IMessage> {
+interface MessageTextProps<TMessage extends IMessage> {
   position: 'left' | 'right'
   currentMessage?: TMessage
   containerStyle?: LeftRightStyle<ViewStyle>
@@ -62,7 +62,7 @@ interface MessageTextProps<TMessage extends IMessage = IMessage> {
   parsePatterns?(linkStyle: TextStyle): any
 }
 
-export default class MessageText extends React.Component<MessageTextProps> {
+export default class MessageText<TMessage extends IMessage = IMessage> extends React.Component<MessageTextProps<TMessage>> {
   static contextTypes = {
     actionSheet: PropTypes.func,
   }
@@ -100,7 +100,7 @@ export default class MessageText extends React.Component<MessageTextProps> {
     customTextStyle: PropTypes.object,
   }
 
-  shouldComponentUpdate(nextProps: MessageTextProps) {
+  shouldComponentUpdate(nextProps: MessageTextProps<TMessage>) {
     return (
       !!this.props.currentMessage &&
       !!nextProps.currentMessage &&

--- a/src/MessageVideo.tsx
+++ b/src/MessageVideo.tsx
@@ -4,7 +4,7 @@ import { View, ViewPropTypes, ViewStyle } from 'react-native'
 import Video, { VideoProperties } from 'react-native-video'
 import { IMessage } from './types'
 
-interface MessageVideoProps<TMessage extends IMessage = IMessage> {
+interface MessageVideoProps<TMessage extends IMessage> {
   currentMessage?: TMessage
   containerStyle?: ViewStyle
   videoStyle?: ViewStyle
@@ -13,7 +13,7 @@ interface MessageVideoProps<TMessage extends IMessage = IMessage> {
   lightboxProps?: object
 }
 
-export default class MessageVideo extends React.Component<MessageVideoProps> {
+export default class MessageVideo<TMessage extends IMessage = IMessage> extends React.Component<MessageVideoProps<TMessage>> {
   static defaultProps = {
     currentMessage: {
       video: null,

--- a/src/MessageVideo.tsx
+++ b/src/MessageVideo.tsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { View, ViewPropTypes, ViewStyle } from 'react-native'
+import { View, ViewPropTypes, StyleProp, ViewStyle } from 'react-native'
 import Video, { VideoProperties } from 'react-native-video'
 import { IMessage } from './types'
 
 interface MessageVideoProps<TMessage extends IMessage> {
   currentMessage?: TMessage
-  containerStyle?: ViewStyle
-  videoStyle?: ViewStyle
+  containerStyle?: StyleProp<ViewStyle>
+  videoStyle?: StyleProp<ViewStyle>
   videoProps?: Partial<VideoProperties>
   // TODO: should be LightBox properties
   lightboxProps?: object

--- a/src/Send.tsx
+++ b/src/Send.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
   ViewPropTypes,
+  StyleProp,
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -30,8 +31,8 @@ const styles = StyleSheet.create({
 interface SendProps {
   text?: string
   label?: string
-  containerStyle?: ViewStyle
-  textStyle?: TextStyle
+  containerStyle?: StyleProp<ViewStyle>
+  textStyle?: StyleProp<TextStyle>
   children?: React.ReactNode
   alwaysShowSend?: boolean
   disabled?: boolean

--- a/src/SystemMessage.tsx
+++ b/src/SystemMessage.tsx
@@ -5,6 +5,7 @@ import {
   View,
   ViewPropTypes,
   ViewStyle,
+  StyleProp,
   TextStyle,
 } from 'react-native'
 import PropTypes from 'prop-types'
@@ -29,9 +30,9 @@ const styles = StyleSheet.create({
 
 interface SystemMessageProps<TMessage extends IMessage> {
   currentMessage?: TMessage
-  containerStyle?: ViewStyle
-  wrapperStyle?: ViewStyle
-  textStyle?: TextStyle
+  containerStyle?: StyleProp<ViewStyle>
+  wrapperStyle?: StyleProp<ViewStyle>
+  textStyle?: StyleProp<TextStyle>
 }
 
 export default class SystemMessage<TMessage extends IMessage = IMessage> extends Component<SystemMessageProps<TMessage>> {

--- a/src/SystemMessage.tsx
+++ b/src/SystemMessage.tsx
@@ -27,14 +27,14 @@ const styles = StyleSheet.create({
   },
 })
 
-interface SystemMessageProps<TMessage extends IMessage = IMessage> {
+interface SystemMessageProps<TMessage extends IMessage> {
   currentMessage?: TMessage
   containerStyle?: ViewStyle
   wrapperStyle?: ViewStyle
   textStyle?: TextStyle
 }
 
-export default class SystemMessage extends Component<SystemMessageProps> {
+export default class SystemMessage<TMessage extends IMessage = IMessage> extends Component<SystemMessageProps<TMessage>> {
   static defaultProps = {
     currentMessage: {
       system: false,
@@ -50,6 +50,7 @@ export default class SystemMessage extends Component<SystemMessageProps> {
     wrapperStyle: ViewPropTypes.style,
     textStyle: PropTypes.any,
   }
+  
   render() {
     const {
       currentMessage,

--- a/src/Time.tsx
+++ b/src/Time.tsx
@@ -48,7 +48,7 @@ const styles = {
   }),
 }
 
-interface TimeProps<TMessage extends IMessage = IMessage> {
+interface TimeProps<TMessage extends IMessage> {
   position: 'left' | 'right'
   currentMessage?: TMessage
   containerStyle?: LeftRightStyle<ViewStyle>
@@ -56,7 +56,7 @@ interface TimeProps<TMessage extends IMessage = IMessage> {
   timeFormat?: string
 }
 
-export default class Time extends Component<TimeProps> {
+export default class Time<TMessage extends IMessage = IMessage> extends Component<TimeProps<TMessage>> {
   static contextTypes = {
     getLocale: PropTypes.func,
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
+import { StyleProp } from 'react-native';
+
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 export interface LeftRightStyle<T> {
-  left: T
-  right: T
+  left: StyleProp<T>
+  right: StyleProp<T>
 }
 type renderFunction = (x: any) => JSX.Element
 export interface User {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 import { StyleProp } from 'react-native';
 
+export {
+  RenderMessageImageProps,
+  RenderMessageVideoProps,
+  RenderMessageTextProps,
+} from './Bubble';
+
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 export interface LeftRightStyle<T> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,11 @@
 import moment from 'moment'
 import { IMessage } from './types'
 
-export function isSameDay(currentMessage: IMessage, diffMessage: IMessage) {
-  if (!diffMessage.createdAt) {
+export function isSameDay(
+  currentMessage: IMessage,
+  diffMessage: IMessage | null | undefined,
+) {
+  if (!diffMessage || !diffMessage.createdAt) {
     return false
   }
 
@@ -16,8 +19,12 @@ export function isSameDay(currentMessage: IMessage, diffMessage: IMessage) {
   return currentCreatedAt.isSame(diffCreatedAt, 'day')
 }
 
-export function isSameUser(currentMessage: IMessage, diffMessage: IMessage) {
+export function isSameUser(
+  currentMessage: IMessage,
+  diffMessage: IMessage | null | undefined,
+) {
   return !!(
+    diffMessage &&
     diffMessage.user &&
     currentMessage.user &&
     diffMessage.user._id === currentMessage.user._id


### PR DESCRIPTION
Currently, all the components have generic props but don't actually make use of the generic, it always defaults to `IMessage`. This allows users to have a custom `Message` type (as long as it extends `IMessage`).

I also changed the utils to allow null/undefined values for diffMessage. The type of `props.previousMessage` is an optional, so we should allow passing in a potentially null/undefined value for diffMessage to make it easier/cleaner to use without having to do a check on `props.previousMessage` first.

Lastly, the type of style props should be wrapped in `StyleProp<>` in order to handle the various types of styles you can get from StyleSheet.create/inline styles, etc.