### PR TITLE
Update to advice for avoiding Keyboard when using Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,20 @@ If you are using Create React Native App / Expo, no Android specific installatio
 
 - For **Expo**, there are almost 2 solutions to fix it:
 
-  - adding KeyboardAvoidingView after GiftedChat [see this comment](https://github.com/FaridSafi/react-native-gifted-chat/issues/461#issuecomment-314858092)
-  - adding an opaque background status bar on app.json https://docs.expo.io/versions/latest/guides/configuration.html#androidstatusbar
+  - Wrap Gifted Chat in a [`KeyboardAvoidingView`](https://facebook.github.io/react-native/docs/keyboardavoidingview). This should only be done for Android, as `KeyboardAvoidingView` may conflict with the iOS keyboard avoidance already built into Gifted Chat, e.g.:
+```
+<View style={{ flex: 1 }}>
+   {
+      Platform.OS === 'android' ?
+         <KeyboardAvoidingView behavior="padding">
+            <GiftedChat ... />
+         </KeyboardAvoidingView> :
+         <GiftedChat ... />
+   }
+</View>
+```
+If you use React Navigation, additional handling may be required to account for navigation headers and tabs. `KeyboardAvoidingView`'s `keyboardVerticalOffset` property can be set to the height of the navigation header and [`tabBarOptions.keyboardHidesTabBar`](https://reactnavigation.org/docs/en/bottom-tab-navigator.html#bottomtabnavigatorconfig) can be set to keep the tab bar from being shown when the keyboard is up. Due to a [bug with calculating height on Android phones with notches](facebook/react-native#23693), `KeyboardAvoidingView` is recommended over other solutions that involve calculating the height of the window.
+  - adding an opaque background status bar on app.json (even though `android:windowSoftInputMode="adjustResize"` is set internally on Expo's Android apps, the transulcent status bar causes it not to work): https://docs.expo.io/versions/latest/guides/configuration.html#androidstatusbar
 
 - If you plan to use `GiftedChat` inside a `Modal`, see [#200](https://github.com/FaridSafi/react-native-gifted-chat/issues/200).
 

--- a/README.md
+++ b/README.md
@@ -377,17 +377,17 @@ If you are using Create React Native App / Expo, no Android specific installatio
     android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
   ```
 
-- For **Expo**, there are almost 2 solutions to fix it:
+- For **Expo**, there are at least 2 solutions to fix it:
 
-  - Wrap Gifted Chat in a [`KeyboardAvoidingView`](https://facebook.github.io/react-native/docs/keyboardavoidingview). This should only be done for Android, as `KeyboardAvoidingView` may conflict with the iOS keyboard avoidance already built into Gifted Chat, e.g.:
+  - Wrap GiftedChat in a [`KeyboardAvoidingView`](https://facebook.github.io/react-native/docs/keyboardavoidingview). This should only be done for Android, as `KeyboardAvoidingView` may conflict with the iOS keyboard avoidance already built into GiftedChat, e.g.:
 ```
 <View style={{ flex: 1 }}>
    {
       Platform.OS === 'android' ?
          <KeyboardAvoidingView behavior="padding">
-            <GiftedChat ... />
+            <GiftedChat />
          </KeyboardAvoidingView> :
-         <GiftedChat ... />
+         <GiftedChat />
    }
 </View>
 ```


### PR DESCRIPTION
Updated instructions per finding here (https://github.com/FaridSafi/react-native-gifted-chat/issues/461#issuecomment-509371173) that currently-linked solution no longer works for Android phones with notches.