### PR TITLE
Add containerStyle also to QuickReplies

### DIFF
--- a/src/QuickReplies.tsx
+++ b/src/QuickReplies.tsx
@@ -46,6 +46,7 @@ export interface QuickRepliesProps {
   quickReplyStyle?: StyleProp<ViewStyle>
   onQuickReply?(reply: Reply[]): void
   renderQuickReplySend?(): React.ReactNode
+  containerStyle?: StyleProp<ViewStyle>
 }
 
 export interface QuickRepliesState {
@@ -72,6 +73,7 @@ export default class QuickReplies extends Component<
     keepReplies: false,
     renderQuickReplySend: undefined,
     quickReplyStyle: undefined,
+    containerStye: undefined,
   }
 
   static propTypes = {
@@ -159,7 +161,7 @@ export default class QuickReplies extends Component<
   }
 
   render() {
-    const { currentMessage, color, quickReplyStyle } = this.props
+    const { currentMessage, color, quickReplyStyle, containerStyle} = this.props
     const { replies } = this.state
 
     if (!this.shouldComponentDisplay()) {
@@ -169,7 +171,7 @@ export default class QuickReplies extends Component<
     const { type } = currentMessage!.quickReplies!
 
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, containerStyle]}>
         {currentMessage!.quickReplies!.values.map((reply: Reply) => {
           const selected = type === 'checkbox' && replies.find(sameReply(reply))
           return (


### PR DESCRIPTION
Added containerStyle to Quickreplies in order to enable overwriting of hard style assumptions
(e.g. flexDirection row instead of column)
Real life use case, enable quick replies that are on top of each other and not next to each other

![photo5868279302347403518](https://user-images.githubusercontent.com/1478557/61300149-b94fb680-a7e1-11e9-8c7e-aac3cfc6ccd6.jpg)

Please review if there is any other way of implementing this behaviour without overriding renderQuickReplies in Bubble or of the intention if this library is to provide this capability only with overriding