### PR TITLE
adds option to disable keyboard sizing handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ interface QuickReplies {
 - **`listViewProps`** _(Object)_ - Extra props to be passed to the messages [`<ListView>`](https://facebook.github.io/react-native/docs/listview.html); some props can't be overridden, see the code in `MessageContainer.render()` for details
 - **`textInputProps`** _(Object)_ - Extra props to be passed to the [`<TextInput>`](https://facebook.github.io/react-native/docs/textinput.html)
 - **`keyboardShouldPersistTaps`** _(Enum)_ - Determines whether the keyboard should stay visible after a tap; see [`<ScrollView>`](https://facebook.github.io/react-native/docs/scrollview.html) docs
+* **`disableKeyboardHandling`** _(Bool)_ - Disable resizing of the messages container view when keyboard is shown
 - **`onInputTextChanged`** _(Function)_ - Callback when the input text changes
 - **`maxInputLength`** _(Integer)_ - Max message composer TextInput length
 - **`parsePatterns`** _(Function)_ - Custom parse patterns for [react-native-parsed-text](https://github.com/taskrabbit/react-native-parsed-text) used to linkify message content (like URLs and phone numbers), e.g.:

--- a/src/GiftedAvatar.tsx
+++ b/src/GiftedAvatar.tsx
@@ -47,6 +47,7 @@ export interface GiftedAvatarProps {
   avatarStyle?: StyleProp<ImageStyle>
   textStyle?: StyleProp<TextStyle>
   onPress?(props: any): void
+  onLongPress?(props: any): void
 }
 
 export default class GiftedAvatar extends React.Component<GiftedAvatarProps> {
@@ -56,6 +57,7 @@ export default class GiftedAvatar extends React.Component<GiftedAvatarProps> {
       avatar: null,
     },
     onPress: null,
+    onLongPress: null,
     avatarStyle: {},
     textStyle: {},
   }
@@ -63,6 +65,7 @@ export default class GiftedAvatar extends React.Component<GiftedAvatarProps> {
   static propTypes = {
     user: PropTypes.object,
     onPress: PropTypes.func,
+    onLongPress: PropTypes.func,
   }
 
   avatarName?: string = undefined

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -87,6 +87,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   textInputProps?: any
   /*Determines whether the keyboard should stay visible after a tap; see <ScrollView> docs */
   keyboardShouldPersistTaps?: any
+  /* Do not resize >MessageContainer> on keyboardDidShow */
+  disableKeyboardHandling?: boolean
   /*Max message composer TextInput length */
   maxInputLength?: number
   /* Force getting keyboard height to fix some display issues */
@@ -222,7 +224,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     textInputProps: {},
     listViewProps: {},
     renderCustomView: null,
-    isCustomViewBottom: false,
     renderDay: null,
     renderTime: null,
     renderFooter: null,
@@ -239,6 +240,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       ios: 'never',
       android: 'always',
     }),
+    disableKeyboardHandling: false,
     onInputTextChanged: null,
     maxInputLength: null,
     forceGetKeyboardHeight: false,
@@ -296,6 +298,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     minInputToolbarHeight: PropTypes.number,
     listViewProps: PropTypes.object,
     keyboardShouldPersistTaps: PropTypes.oneOf(['always', 'never', 'handled']),
+    disableKeyboardHandling: PropTypes.bool,
     onInputTextChanged: PropTypes.func,
     maxInputLength: PropTypes.number,
     forceGetKeyboardHeight: PropTypes.bool,
@@ -540,37 +543,41 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
 
   onKeyboardWillShow = (e: any) => {
     this.setIsTypingDisabled(true)
-    this.setKeyboardHeight(
-      e.endCoordinates ? e.endCoordinates.height : e.end.height,
-    )
-    this.setBottomOffset(this.safeAreaIphoneX(this.props.bottomOffset!))
-    const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
-    if (this.props.isAnimated === true) {
-      Animated.timing(this.state.messagesContainerHeight!, {
-        toValue: newMessagesContainerHeight,
-        duration: 210,
-      }).start()
-    } else {
-      this.setState({
-        messagesContainerHeight: newMessagesContainerHeight,
-      })
+    if (!this.props.disableKeyboardHandling){
+      this.setKeyboardHeight(
+        e.endCoordinates ? e.endCoordinates.height : e.end.height,
+      )
+      this.setBottomOffset(this.safeAreaIphoneX(this.props.bottomOffset!))
+      const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
+      if (this.props.isAnimated === true) {
+        Animated.timing(this.state.messagesContainerHeight!, {
+          toValue: newMessagesContainerHeight,
+          duration: 210,
+        }).start()
+      } else {
+        this.setState({
+          messagesContainerHeight: newMessagesContainerHeight,
+        })
+      }
     }
   }
 
   onKeyboardWillHide = (_e: any) => {
     this.setIsTypingDisabled(true)
-    this.setKeyboardHeight(0)
-    this.setBottomOffset(0)
-    const newMessagesContainerHeight = this.getBasicMessagesContainerHeight()
-    if (this.props.isAnimated === true) {
-      Animated.timing(this.state.messagesContainerHeight!, {
-        toValue: newMessagesContainerHeight,
-        duration: 210,
-      }).start()
-    } else {
-      this.setState({
-        messagesContainerHeight: newMessagesContainerHeight,
-      })
+    if (!this.props.disableKeyboardHandling){
+      this.setKeyboardHeight(0)
+      this.setBottomOffset(0)
+      const newMessagesContainerHeight = this.getBasicMessagesContainerHeight()
+      if (this.props.isAnimated === true) {
+        Animated.timing(this.state.messagesContainerHeight!, {
+          toValue: newMessagesContainerHeight,
+          duration: 210,
+        }).start()
+      } else {
+        this.setState({
+          messagesContainerHeight: newMessagesContainerHeight,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
This is to fix fix some issues when keyboard is handled outside of the `GiftedChat` container, as discussed in https://github.com/FaridSafi/react-native-gifted-chat/pull/1171.
In my case, I use a `KeyboardSpacer` at the very root of my app, so I don't need this library to deal with that. 
A work-around would have been to wrap my root into a context, and disable the `KeyboardSpacer` on any view that presents a `GiftedChat`.

Hope you find this useful, and up to your coding standards 👍🏻

Any comments welcome, always.


---------------
_This also includes fix done in https://github.com/FaridSafi/react-native-gifted-chat/pull/1324_ 