### PR TITLE
fix message got cut off by messageContainer when scrolling after alignTop={true} on ios

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -324,6 +324,7 @@ export default class MessageContainer<
           ListHeaderComponent={this.renderFooter}
           onScroll={this.handleOnScroll}
           scrollEventThrottle={100}
+          bounces={this.props.alignTop ? false : true}
           {...this.props.listViewProps}
         />
       </View>


### PR DESCRIPTION
- just because of overscroll(bounce) feature only on ios
- add bounce={this.props.alignTop ? false : true} to FlatList in messageContainer

I think..... resolves #1227