### PR TITLE
No loading indicator when messages list is empty.

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -293,12 +293,6 @@ export default class MessageContainer<
   keyExtractor = (item: TMessage) => `${item._id}`
 
   render() {
-    if (
-      !this.props.messages ||
-      (this.props.messages && this.props.messages.length === 0)
-    ) {
-      return <View style={styles.container} />
-    }
     return (
       <View
         style={


### PR DESCRIPTION
No loading indicator is displayed (even if `loadingEarlier` and `isLoadingEarlier` are both `true`) if the list of messages is empty. 