### PR TITLE
locale prop fix

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -12,6 +12,7 @@ import {
 
 import ActionSheet from '@expo/react-native-action-sheet'
 import moment from 'moment'
+import 'moment/min/locales';
 import uuid from 'uuid'
 import { isIphoneX } from 'react-native-iphone-x-helper'
 


### PR DESCRIPTION
At the moment `moment.locales().indexOf(locale)` always returns `-1` for any locale other than `en`. Locale files needs to be imported first. `moment/min/locales` contains all the locale files so with this PR changing the locale prop will take affect.

#1350