### PR TITLE
sending giftedChat props to renderChatFooter function prop

### DIFF
--- a/flow-typedefs/GiftedChat.js.flow
+++ b/flow-typedefs/GiftedChat.js.flow
@@ -46,6 +46,7 @@ export type GiftedChatProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
   alignTop?: boolean,
   scrollToBottom?: boolean,
   scrollToBottomStyle?: ViewStyleProp,
+  scrollToBottomComponent?: () => React.Node,
   initialText?: string,
   placeholder?: string,
   user?: User,

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -173,6 +173,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   onQuickReply?(replies: Reply[]): void
   renderQuickReplies?(quickReplies: QuickReplies['props']): React.ReactNode
   renderQuickReplySend?(): React.ReactNode
+  /* Scroll to bottom custom component */
+  scrollToBottomComponent?(): React.ReactNode
   shouldUpdateMessage?(
     props: Message['props'],
     nextProps: Message['props'],


### PR DESCRIPTION
ExtraData property of gifted chat can't be accessed in renderChatFooter. So, Sending giftedChat Props to renderChatfooter prop function