### PR TITLE
Improve keyboard performance revisited

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ interface QuickReplies {
 - **`locale`** _(String)_ - Locale to localize the dates
 - **`timeFormat`** _(String)_ - Format to use for rendering times; default is `'LT'`
 - **`dateFormat`** _(String)_ - Format to use for rendering dates; default is `'ll'`
-- **`isAnimated`** _(Bool)_ - Animates the view when the keyboard appears
 - **`loadEarlier`** _(Bool)_ - Enables the "load earlier messages" button
+- **`isKeyboardInternallyHandled`** _(Bool)_ - Determine whether to handle keyboard awareness inside the plugin. If you have your own keyboard handling outside the plugin set this to false; default is `true`
 - **`onLoadEarlier`** _(Function)_ - Callback when loading earlier messages
 - **`isLoadingEarlier`** _(Bool)_ - Display an `ActivityIndicator` when loading earlier messages
 - **`renderLoading`** _(Function)_ - Render a loading view when initializing

--- a/flow-typedefs/GiftedChat.js.flow
+++ b/flow-typedefs/GiftedChat.js.flow
@@ -53,7 +53,7 @@ export type GiftedChatProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
   locale?: string,
   timeFormat?: string,
   dateFormat?: string,
-  isAnimated?: boolean,
+  isKeyboardInternallyHandled?: boolean,
   loadEarlier?: boolean,
   isLoadingEarlier?: boolean,
   showUserAvatar?: boolean,

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -272,6 +272,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     locale: PropTypes.string,
     timeFormat: PropTypes.string,
     dateFormat: PropTypes.string,
+    isKeyboardInternallyHandled: PropTypes.bool,
     loadEarlier: PropTypes.bool,
     onLoadEarlier: PropTypes.func,
     isLoadingEarlier: PropTypes.bool,

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -612,41 +612,26 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   }
 
   renderMessages() {
-    return (
-      <>
-        {this.props.isKeyboardInternallyHandled && (
-          <KeyboardAvoidingView enabled>
-            <View
-              style={{
-                height: this.state.messagesContainerHeight,
-              }}
-            >
-              <MessageContainer
-                {...this.props}
-                invertibleScrollViewProps={this.invertibleScrollViewProps}
-                messages={this.getMessages()}
-                forwardRef={this._messageContainerRef}
-              />
-              {this.renderChatFooter()}
-            </View>
-          </KeyboardAvoidingView>
-        )}
-        {!this.props.isKeyboardInternallyHandled && (
-          <View
-            style={{
-              height: this.state.messagesContainerHeight,
-            }}
-          >
-            <MessageContainer
-              {...this.props}
-              invertibleScrollViewProps={this.invertibleScrollViewProps}
-              messages={this.getMessages()}
-              forwardRef={this._messageContainerRef}
-            />
-            {this.renderChatFooter()}
-          </View>
-        )}
-      </>
+    const fragment = (
+      <View
+        style={{
+          height: this.state.messagesContainerHeight,
+        }}
+      >
+        <MessageContainer
+          {...this.props}
+          invertibleScrollViewProps={this.invertibleScrollViewProps}
+          messages={this.getMessages()}
+          forwardRef={this._messageContainerRef}
+        />
+        {this.renderChatFooter()}
+      </View>
+    )
+
+    return this.props.isKeyboardInternallyHandled ? (
+      <KeyboardAvoidingView enabled>{fragment}</KeyboardAvoidingView>
+    ) : (
+      fragment
     )
   }
 


### PR DESCRIPTION
This PR incorporates #1171, #1326  by adding the `isKeyboardInternallyHandled` prop. When set to true, a KeyboardAvoidingView is added from react-native in order to make the animation smoother on the textbox above the keyboard.

When the prop is set to false, there is only a View with no animation. This gives the option for users to use their own keyboard handlers.

Also to address @llamaluvr concerns about offering an offset prop for people's chrome. This  prop was never needed because the keyboard avoider only smooths the animation, it doesn't actually handle the keyboard.

Let me know if you have any questions.