### PR TITLE
Implement renderChatEmpty for when messages are empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ interface QuickReplies {
 - **`renderDay`** _(Function)_ - Custom day above a message
 - **`renderTime`** _(Function)_ - Custom time inside a message
 - **`renderFooter`** _(Function)_ - Custom footer component on the ListView, e.g. `'User is typing...'`; see [example/App.js](example/App.js) for an example
+- **`renderChatEmpty`** _(Function)_ - Custom component to render in the ListView when messages are empty
 - **`renderChatFooter`** _(Function)_ - Custom component to render below the MessageContainer (separate from the ListView)
 - **`renderInputToolbar`** _(Function)_ - Custom message composer container
 - **`renderComposer`** _(Function)_ - Custom text input message composer

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -152,6 +152,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   renderTime?(props: Time['props']): React.ReactNode
   /* Custom footer component on the ListView, e.g. 'User is typing...' */
   renderFooter?(): React.ReactNode
+  /* Custom component to render in the ListView when messages are empty */
+  renderChatEmpty?(): React.ReactNode
   /* Custom component to render below the MessageContainer (separate from the ListView) */
   renderChatFooter?(): React.ReactNode
   /* Custom message composer container */
@@ -241,6 +243,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     renderDay: null,
     renderTime: null,
     renderFooter: null,
+    renderChatEmpty: null,
     renderChatFooter: null,
     renderInputToolbar: null,
     renderComposer: null,
@@ -301,6 +304,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     renderDay: PropTypes.func,
     renderTime: PropTypes.func,
     renderFooter: PropTypes.func,
+    renderChatEmpty: PropTypes.func,
     renderChatFooter: PropTypes.func,
     renderInputToolbar: PropTypes.func,
     renderComposer: PropTypes.func,

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -31,7 +31,8 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
   },
   contentContainerStyle: {
-    justifyContent: 'flex-end',
+    flexGrow: 1,
+    justifyContent: 'flex-start',
   },
   headerWrapper: {
     flex: 1,
@@ -71,6 +72,7 @@ export interface MessageContainerProps<TMessage extends IMessage> {
   extraData?: any
   scrollToBottomOffset?: number
   forwardRef?: RefObject<FlatList<IMessage>>
+  renderChatEmpty?(): React.ReactNode
   renderFooter?(props: MessageContainerProps<TMessage>): React.ReactNode
   renderMessage?(props: Message['props']): React.ReactNode
   renderLoadEarlier?(props: LoadEarlier['props']): React.ReactNode
@@ -89,6 +91,7 @@ export default class MessageContainer<
   static defaultProps = {
     messages: [],
     user: {},
+    renderChatEmpty: null,
     renderFooter: null,
     renderMessage: null,
     onLoadEarlier: () => {},
@@ -107,6 +110,7 @@ export default class MessageContainer<
   static propTypes = {
     messages: PropTypes.arrayOf(PropTypes.object),
     user: PropTypes.object,
+    renderChatEmpty: PropTypes.func,
     renderFooter: PropTypes.func,
     renderMessage: PropTypes.func,
     renderLoadEarlier: PropTypes.func,
@@ -294,6 +298,13 @@ export default class MessageContainer<
     return null
   }
 
+  renderChatEmpty = () => {
+    if (this.props.renderChatEmpty) {
+      return this.props.renderChatEmpty()
+    }
+    return <View style={styles.container} />
+  }
+
   renderHeaderWrapper = () => (
     <View style={styles.headerWrapper}>{this.renderLoadEarlier()}</View>
   )
@@ -338,12 +349,6 @@ export default class MessageContainer<
   keyExtractor = (item: TMessage) => `${item._id}`
 
   render() {
-    if (
-      !this.props.messages ||
-      (this.props.messages && this.props.messages.length === 0)
-    ) {
-      return <View style={styles.container} />
-    }
     const { inverted } = this.props
     return (
       <View
@@ -366,6 +371,7 @@ export default class MessageContainer<
           contentContainerStyle={styles.contentContainerStyle}
           renderItem={this.renderRow}
           {...this.props.invertibleScrollViewProps}
+          ListEmptyComponent={this.renderChatEmpty}
           ListFooterComponent={
             inverted ? this.renderHeaderWrapper : this.renderFooter
           }


### PR DESCRIPTION
This PR implements renderChatEmpty prop on GiftedChat component to allow rendering custom empty view for when the messages prop are empty.

When no value is set, it renders a default empty container view with `flex: 1`, which behaves similarly to the previous implementation but with one difference. The empty view is now always rendered in ListEmptyComponent to allow dismissing keyboard by tapping the empty view just like when the messages are displayed in the MessageContainer.

Unfortunately, due to a bug in some React Native versions including the latest,
when `inverted={false}` is specified in `<GiftedChat>` component and the internal FlatList is inverted, 
the ListEmptyView is rendered upside down (See https://github.com/facebook/react-native/issues/21196
).
I believe the bug should be addressed in React Native itself or a workaround should be implemented in the app by the user, as an upgrade could break the workaround easily. My current workaround looks like this.

```
<GiftedChat
messages={[]]
renderChatEmpty={() =>
  <View style={{transform: [{ scaleY: -1 }]}}>
    <Text>Messages are empty!</Text>
  </View>
}
/>
```

The default empty view is unaffected as it just renders a blank view.




