### PR TITLE
adjust message container height with input toolbar/accessory height change

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -421,6 +421,14 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     if (text !== prevProps.text) {
       this.setTextFromProp(text)
     }
+
+    if (prevProps.minInputToolbarHeight !== this.props.minInputToolbarHeight) {
+      this.setState({
+        messagesContainerHeight: this.prepareMessagesContainerHeight(
+          this.getBasicMessagesContainerHeight(),
+        ),
+      })
+    }
   }
 
   initLocale() {


### PR DESCRIPTION
Currently the message container height reamins the same & does not update/adjust with input toolbar/custom accessory height change. The related issue - https://github.com/FaridSafi/react-native-gifted-chat/issues/911.

This PR will update the message container height if the input toolbar height is updated.