### PR TITLE
fixed bug

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -340,7 +340,7 @@ export default class MessageContainer<
       this.props.messages!.length
     ) {
       setTimeout(
-        () => this.scrollToBottom(false),
+        () => this.scrollToBottom && this.scrollToBottom(false),
         15 * this.props.messages!.length,
       )
     }


### PR DESCRIPTION
fixed possible bug if inverted={false} prop is provided.

The bug produces `cannot read property scrollToEnd of null` when the component is unmounted