### PR TITLE
add disableComposer prop

### DIFF
--- a/src/Composer.tsx
+++ b/src/Composer.tsx
@@ -39,6 +39,7 @@ export interface ComposerProps {
   textInputAutoFocus?: boolean
   keyboardAppearance?: TextInputProps['keyboardAppearance']
   multiline?: boolean
+  disableComposer?: boolean
   onTextChanged?(text: string): void
   onInputSizeChanged?(contentSize: { width: number; height: number }): void
 }
@@ -51,6 +52,7 @@ export default class Composer extends React.Component<ComposerProps> {
     placeholder: DEFAULT_PLACEHOLDER,
     textInputProps: null,
     multiline: true,
+    disableComposer: false,
     textInputStyle: {},
     textInputAutoFocus: false,
     keyboardAppearance: 'default',
@@ -67,6 +69,7 @@ export default class Composer extends React.Component<ComposerProps> {
     onTextChanged: PropTypes.func,
     onInputSizeChanged: PropTypes.func,
     multiline: PropTypes.bool,
+    disableComposer: PropTypes.bool,
     textInputStyle: PropTypes.any,
     textInputAutoFocus: PropTypes.bool,
     keyboardAppearance: PropTypes.string,
@@ -106,6 +109,7 @@ export default class Composer extends React.Component<ComposerProps> {
         placeholder={this.props.placeholder}
         placeholderTextColor={this.props.placeholderTextColor}
         multiline={this.props.multiline}
+        editable={!(this.props.disableComposer)}
         onChange={this.onContentSizeChange}
         onContentSizeChange={this.onContentSizeChange}
         onChangeText={this.onChangeText}

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -63,6 +63,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   initialText?: string
   /* Placeholder when text is empty; default is 'Type a message...' */
   placeholder?: string
+  /* Makes the composer not editable*/
+  disableComposer?: boolean
   /* User sending the messages: { _id, name, avatar } */
   user?: User
   /*  Locale to localize the dates */
@@ -209,6 +211,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     messagesContainerStyle: undefined,
     text: undefined,
     placeholder: DEFAULT_PLACEHOLDER,
+    disableComposer: false,
     messageIdGenerator: () => uuid.v4(),
     user: {},
     onSend: () => {},
@@ -276,6 +279,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     text: PropTypes.string,
     initialText: PropTypes.string,
     placeholder: PropTypes.string,
+    disableComposer: PropTypes.bool,
     messageIdGenerator: PropTypes.func,
     user: PropTypes.object,
     onSend: PropTypes.func,


### PR DESCRIPTION
Fix disableComposer Issue, Disabled composer user can only view the chat can't respond.

Issue Reference [Temporarily disable TextInput #1554](https://github.com/FaridSafi/react-native-gifted-chat/issues/1554)  