### PR TITLE
Updated deprecated lifecycle method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ class Example extends React.Component {
     messages: [],
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setState({
       messages: [
         {


### PR DESCRIPTION
componentWillMount() is deprecated since React Native 0.54 / ReactJS 16.3, replaced it with componentDidMount() in the example to prevent confusion