### PR TITLE
Fix REDME.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ interface QuickReplies {
 - **`renderMessageText`** _(Function)_ - Custom message text
 - **`renderMessageImage`** _(Function)_ - Custom message image
 - **`renderMessageVideo`** _(Function)_ - Custom message video
-- **image props`** _(Object)_ - Extra props to be passed to the [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component created by the default `renderMessageImage`
+- **`image props`** _(Object)_ - Extra props to be passed to the [`<Image>`](https://facebook.github.io/react-native/docs/image.html) component created by the default `renderMessageImage`
 - **`videoProps`** _(Object)_ - Extra props to be passed to the video component created by the required `renderMessageVideo`
 - **`lightboxProps`** _(Object)_ - Extra props to be passed to the `MessageImage`'s [Lightbox](https://github.com/oblador/react-native-lightbox)
 - **`isCustomViewBottom`** _(Bool)_ - Determine whether renderCustomView is displayed before or after the text, image and video views; default is `false`


### PR DESCRIPTION
## About
- In README.md Line304, It seems to be missing `` ` `` before  `image props`.  So README is not drawn correctly.
- before : <img width="862" alt="スクリーンショット 2019-12-28 18 29 21" src="https://user-images.githubusercontent.com/14814057/71541844-478bb380-29a2-11ea-8012-1a2d37bffd17.png">
- after : <img width="825" alt="スクリーンショット 2019-12-28 18 28 51" src="https://user-images.githubusercontent.com/14814057/71541842-3d69b500-29a2-11ea-990a-0f9cd3f3a208.png">


