### PR TITLE
fix null ref case in MessageContainer

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -237,7 +237,7 @@ export default class MessageContainer<
     const { inverted } = this.props
     if (inverted) {
       this.scrollTo({ offset: 0, animated })
-    } else {
+    } else if (this.props.forwardRef && this.props.forwardRef.current) {
       this.props.forwardRef!.current!.scrollToEnd({ animated })
     }
   }


### PR DESCRIPTION
I got a crash when using this component in React Native, the crash report is:

```
User comment: opened a conversation then immediately pressed back; app had just opened from phone sleep

Stack trace from JavaScript:
com.facebook.react.common.JavascriptException: TypeError: null is not an object (evaluating 't.props.forwardRef.current.scrollToEnd'), stack:
scrollToBottom@1272:2683
<unknown>@1272:4090
y@115:661
callTimers@115:2718
value@28:3685
<unknown>@28:841
value@28:2939
value@28:813
value@-1
```

I just added an if guard. Notice that the line above that calls the `scrollTo` method is actually guarded against nulls (see the implementation of `scrollTo`), but for some reason this line 240 wasn't guarded. I think this is a harmless addition.

PS: thanks for react-native-gifted-chat! Really good component.