### PR TITLE
Typescript - Make createdAt prop optional

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -20,6 +20,54 @@ it('should test if same day', () => {
   ).toBe(true)
 })
 
+it('test both undefined createdAt for same day', () => {
+  expect(
+    isSameDay({
+      _id: 1,
+      text: 'test',
+      user: {_id: 1}
+    }, {
+      _id: 2,
+      text: 'test2',
+      user: {_id: 2}
+    })
+  ).toBe(true)
+})
+
+it('should test undefined currentMessage.createdAt for same day', () => {
+  const now = new Date()
+
+  expect(
+    isSameDay({
+      _id: 1,
+      text: 'test',
+      user: {_id: 1}
+    }, {
+      _id: 2,
+      text: 'test2',
+      createdAt: now,
+      user: {_id: 2}
+    })
+  ).toBe(false)
+})
+
+it('should test undefined diffMessage.createdAt for same day', () => {
+  const now = new Date()
+
+  expect(
+    isSameDay({
+      _id: 1,
+      text: 'test',
+      createdAt: now,
+      user: {_id: 1}
+    }, {
+      _id: 2,
+      text: 'test2',
+      user: {_id: 2}
+    })
+  ).toBe(true)
+})
+
 it('should test if same user', () => {
   const message = {
     _id: 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface QuickReplies {
 export interface IMessage {
   _id: string | number
   text: string
-  createdAt: Date | number
+  createdAt?: Date | number
   user: User
   image?: string
   video?: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,8 +5,12 @@ export function isSameDay(
   currentMessage: IMessage,
   diffMessage: IMessage | null | undefined,
 ) {
-  if (!diffMessage || !diffMessage.createdAt) {
+  if (!diffMessage || (!currentMessage.createdAt && diffMessage.createdAt)) {
     return false
+  }
+
+  if (!diffMessage.createdAt) {
+    return true
   }
 
   const currentCreatedAt = moment(currentMessage.createdAt)


### PR DESCRIPTION
This PR was motivated by a desire to have system messages without a day header. I was using undefined createdAt's before I migrated to typescript when I discovered the issue.

The only issue I see with this PR is the isSameDay function. My understanding of the function is that it is used for determining message styling, whether or not to display an avatar, and whether or not to create a day header. From that perspective isSameDay should return:

- true when both messages have a null createdAt
- true when diffMessage has a null createdAt
- false when currentMessage.createdAt is null and diffMessage.createdAt isn't.

Any thoughts?