### PR TITLE
Remove ViewPropTypes references to support react-native-web >= 0.12.0

### DIFF
--- a/src/Actions.tsx
+++ b/src/Actions.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   TouchableOpacity,
   View,
-  ViewPropTypes,
+  
   StyleProp,
   ViewStyle,
   TextStyle,
@@ -38,8 +38,8 @@ export default class Actions extends React.Component<ActionsProps> {
     optionTintColor: PropTypes.string,
     icon: PropTypes.func,
     onPressActionButton: PropTypes.func,
-    wrapperStyle: ViewPropTypes.style,
-    containerStyle: ViewPropTypes.style,
+    wrapperStyle: {},
+    containerStyle: {},
   }
 
   static contextTypes = {

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react'
 import {
   StyleSheet,
   View,
-  ViewPropTypes,
+  
   ImageStyle,
   ViewStyle,
 } from 'react-native'
@@ -85,12 +85,12 @@ export default class Avatar<
     onLongPressAvatar: PropTypes.func,
     renderAvatar: PropTypes.func,
     containerStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     imageStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
   }
 

--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -6,7 +6,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   View,
-  ViewPropTypes,
+  
   StyleProp,
   ViewStyle,
   TextStyle,
@@ -213,26 +213,26 @@ export default class Bubble<
     nextMessage: PropTypes.object,
     previousMessage: PropTypes.object,
     containerStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     wrapperStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     bottomContainerStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     tickStyle: PropTypes.any,
     usernameStyle: PropTypes.any,
     containerToNextStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     containerToPreviousStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
   }
 

--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -4,7 +4,7 @@ import {
   StyleSheet,
   Text,
   View,
-  ViewPropTypes,
+  
   StyleProp,
   ViewStyle,
   TextStyle,
@@ -68,8 +68,8 @@ export default class Day<
     previousMessage: PropTypes.object,
     nextMessage: PropTypes.object,
     inverted: PropTypes.bool,
-    containerStyle: ViewPropTypes.style,
-    wrapperStyle: ViewPropTypes.style,
+    containerStyle: {},
+    wrapperStyle: {},
     textStyle: PropTypes.any,
     dateFormat: PropTypes.string,
   }

--- a/src/InputToolbar.tsx
+++ b/src/InputToolbar.tsx
@@ -4,7 +4,7 @@ import {
   StyleSheet,
   View,
   Keyboard,
-  ViewPropTypes,
+  
   EmitterSubscription,
   StyleProp,
   ViewStyle,
@@ -67,9 +67,9 @@ export default class InputToolbar extends React.Component<
     renderSend: PropTypes.func,
     renderComposer: PropTypes.func,
     onPressActionButton: PropTypes.func,
-    containerStyle: ViewPropTypes.style,
-    primaryStyle: ViewPropTypes.style,
-    accessoryStyle: ViewPropTypes.style,
+    containerStyle: {},
+    primaryStyle: {},
+    accessoryStyle: {},
   }
 
   state = {

--- a/src/LoadEarlier.tsx
+++ b/src/LoadEarlier.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   TouchableOpacity,
   View,
-  ViewPropTypes,
+  
   StyleProp,
   ViewStyle,
   TextStyle,
@@ -72,10 +72,10 @@ export default class LoadEarlier extends React.Component<LoadEarlierProps> {
     onLoadEarlier: PropTypes.func,
     isLoadingEarlier: PropTypes.bool,
     label: PropTypes.string,
-    containerStyle: ViewPropTypes.style,
-    wrapperStyle: ViewPropTypes.style,
+    containerStyle: {},
+    wrapperStyle: {},
     textStyle: PropTypes.any,
-    activityIndicatorStyle: ViewPropTypes.style,
+    activityIndicatorStyle: {},
     activityIndicatorColor: PropTypes.string,
     activityIndicatorSize: PropTypes.string,
   }

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { View, ViewPropTypes, StyleSheet, ViewStyle } from 'react-native'
+import { View,  StyleSheet, ViewStyle } from 'react-native'
 
 import Avatar from './Avatar'
 import Bubble from './Bubble'
@@ -83,8 +83,8 @@ export default class Message<
     user: PropTypes.object,
     inverted: PropTypes.bool,
     containerStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     shouldUpdateMessage: PropTypes.func,
   }

--- a/src/MessageImage.tsx
+++ b/src/MessageImage.tsx
@@ -4,7 +4,7 @@ import {
   Image,
   StyleSheet,
   View,
-  ViewPropTypes,
+  
   ImageProps,
   ViewStyle,
   StyleProp,
@@ -53,7 +53,7 @@ export default class MessageImage<
 
   static propTypes = {
     currentMessage: PropTypes.object,
-    containerStyle: ViewPropTypes.style,
+    containerStyle: {},
     imageStyle: PropTypes.object,
     imageProps: PropTypes.object,
     lightboxProps: PropTypes.object,

--- a/src/MessageText.tsx
+++ b/src/MessageText.tsx
@@ -4,7 +4,7 @@ import {
   Linking,
   StyleSheet,
   View,
-  ViewPropTypes,
+  
   TextProps,
   StyleProp,
   ViewStyle,
@@ -92,8 +92,8 @@ export default class MessageText<
     optionTitles: PropTypes.arrayOf(PropTypes.string),
     currentMessage: PropTypes.object,
     containerStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     textStyle: PropTypes.shape({
       left: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),

--- a/src/Send.tsx
+++ b/src/Send.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   TouchableOpacity,
   View,
-  ViewPropTypes,
+  
   StyleProp,
   ViewStyle,
   TextStyle,
@@ -58,7 +58,7 @@ export default class Send extends Component<SendProps> {
     text: PropTypes.string,
     onSend: PropTypes.func,
     label: PropTypes.string,
-    containerStyle: ViewPropTypes.style,
+    containerStyle: {},
     textStyle: PropTypes.any,
     children: PropTypes.element,
     alwaysShowSend: PropTypes.bool,

--- a/src/SystemMessage.tsx
+++ b/src/SystemMessage.tsx
@@ -3,7 +3,7 @@ import {
   StyleSheet,
   Text,
   View,
-  ViewPropTypes,
+  
   ViewStyle,
   StyleProp,
   TextStyle,
@@ -49,8 +49,8 @@ export default class SystemMessage<
 
   static propTypes = {
     currentMessage: PropTypes.object,
-    containerStyle: ViewPropTypes.style,
-    wrapperStyle: ViewPropTypes.style,
+    containerStyle: {},
+    wrapperStyle: {},
     textStyle: PropTypes.any,
   }
 

--- a/src/Time.tsx
+++ b/src/Time.tsx
@@ -4,7 +4,7 @@ import {
   StyleSheet,
   Text,
   View,
-  ViewPropTypes,
+  
   ViewStyle,
   TextStyle,
 } from 'react-native'
@@ -77,8 +77,8 @@ export default class Time<
     position: PropTypes.oneOf(['left', 'right']),
     currentMessage: PropTypes.object,
     containerStyle: PropTypes.shape({
-      left: ViewPropTypes.style,
-      right: ViewPropTypes.style,
+      left: {},
+      right: {},
     }),
     timeFormat: PropTypes.string,
     timeTextStyle: PropTypes.shape({


### PR DESCRIPTION
ViewPropTypes is no longer supported on react-native-web > 0.12.0 as described on this issue https://github.com/necolas/react-native-web/issues/1537

