### PR TITLE
Update bottomOffset, fix issues on iPhone X

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -585,7 +585,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   }
 
   safeAreaSupport = (bottomOffset: number) => {
-    return bottomOffset === this._bottomOffset ? getBottomSpace() : bottomOffset
+    return bottomOffset === this._bottomOffset ? (this.getBottomOffset() ? this.getBottomOffset() : getBottomSpace()) : bottomOffset
   }
 
   onKeyboardWillShow = (e: any) => {


### PR DESCRIPTION
This fix is needed, because the current implementation (which triggers on keyboardWillHide for example when you start doing a gesture swipe back gesture and abort it (or when you open the ActionSheet while having focus on input) takes "bottomOffset" parameter, or getBottomSpace (which is always 34). It should check if an actual bottomOffset is set and take that value instead, without it, it breaks custom InputToolbar heights.

It should not break anything, it should fix issues on iPhone X+