### PR TITLE
Fix calculation of messagesContainerHeight in onMainViewLayout if key…

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -784,7 +784,8 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     ) {
       this.setMaxHeight(layout.height)
       this.setState({
-        messagesContainerHeight: this.getBasicMessagesContainerHeight(),
+        messagesContainerHeight: (this._keyboardHeight > 0) ?
+          this.getMessagesContainerHeightWithKeyboard() : this.getBasicMessagesContainerHeight(),
       })
     }
     if (this.getIsFirstLayout() === true) {


### PR DESCRIPTION
…board is shown

Fixes #1766 

If GiftedChat is resized while keyboard is shown (e.g. because GiftedChat is embedded inside a container view, in which dynamic header are resized or shown/hidden), the messagesContainerHeight is calculated without taking the open keyboard view into account. This leads to a situation, where the end of the messages container including the composer is _behind_ the opened keyboard.

![IMG_0176](https://user-images.githubusercontent.com/1336497/80983797-488b9080-8e2d-11ea-81a9-f57f17fdd467.PNG)
