### PR TITLE
DayJS should not have a fixed version in package.json (Duplicate DayJS instance)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.6.0",
-    "dayjs": "1.8.27",
+    "dayjs": "^1.8.26",
     "prop-types": "^15.7.2",
     "react-native-communications": "^2.2.1",
     "react-native-iphone-x-helper": "^1.2.1",


### PR DESCRIPTION
Due to the fixed version of dayjs in the package.json, if you are using another version of dayjs in your package.json application, a copy of dayjs is added in the node_modules of dayjs (transitive dependencies).

Due to this is not possible to load locale files for dayjs in an application, because gifted chat as another instance of dayjs.

The dayjs version must be flexible.

In a more recent commit I saw that you change it to 1.8.27 so people using 1.8.26 willl have the problem.