### PR TITLE
Fix bottom offset issue

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -274,7 +274,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     renderAccessory: null,
     isKeyboardInternallyHandled: true,
     onPressActionButton: null,
-    bottomOffset: 0,
+    bottomOffset: null,
     minInputToolbarHeight: 44,
     keyboardShouldPersistTaps: Platform.select({
       ios: 'never',

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -583,12 +583,8 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     )
   }
 
-  safeAreaSupport = (bottomOffset: number) => {
-    return bottomOffset === this._bottomOffset
-      ? this.getBottomOffset()
-        ? this.getBottomOffset()
-        : getBottomSpace()
-      : bottomOffset
+  safeAreaSupport = (bottomOffset?: number) => {
+    return bottomOffset != null ? bottomOffset : getBottomSpace()
   }
 
   onKeyboardWillShow = (e: any) => {
@@ -597,7 +593,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       this.setKeyboardHeight(
         e.endCoordinates ? e.endCoordinates.height : e.end.height,
       )
-      this.setBottomOffset(this.safeAreaSupport(this.props.bottomOffset!))
+      this.setBottomOffset(this.safeAreaSupport(this.props.bottomOffset))
       const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
       this.setState({
         messagesContainerHeight: newMessagesContainerHeight,


### PR DESCRIPTION
I faced an issue with opened keyboard `bottomOffest` when an action sheet opened and then closed. When I deep into the code, I found that in this case `onKeyboardWillShow` is called two times (as shown in the first video). The issue happens because the two events fired in sequence without`onKeyboardWillHide` event in between so the calculations is failed. As I understood the `safeAreaSupport` should return the `bottomOffest` prop if provided, otherwise return the bottom safe are. Therefore, I adjust it to adapt this logic and this fixed the issue. Actually, I don't sure if my understanding is right so I don't know if there's another cases this will be fail or not 😅

The same issue happens when the chat is empty. I found the reason is that the keyboard events is registered in two places in this case (one in `Messanger` component and the other is `FlatList`). You can see this in the second video. I just wonder why we need to make these two subscriptions. The `FlatList` subscription is already fired even if it's empty.

[Video 1](https://streamable.com/nfj3a7)
[Video 2](https://streamable.com/sme9fh)

P.S. We can also solve this by using `debounce` to neglect one of the two events. This can be used if the original function logic is needed to handle other cases.