### PR TITLE
fix: local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,14 +452,14 @@ If you use React Navigation, additional handling may be required to account for 
 
 ### Native
 
-1. Install `yarn add -g expo-cli`
+1. Install `yarn global add expo-cli`
 2. `expo start`
 
 ### react-native-web
 
 #### With expo
 
-1. Install `yarn add -g expo-cli`
+1. Install `yarn global add expo-cli`
 2. `expo start -w`
 
 [Upgrade snack version](https://snackager.expo.io/bundle/react-native-gifted-chat@0.15.0?bypassCache=true)

--- a/README.md
+++ b/README.md
@@ -453,14 +453,16 @@ If you use React Navigation, additional handling may be required to account for 
 ### Native
 
 1. Install `yarn global add expo-cli`
-2. `expo start`
+2. Install dependencies`yarn install`
+3. `expo start -w`
 
 ### react-native-web
 
 #### With expo
 
 1. Install `yarn global add expo-cli`
-2. `expo start -w`
+2. Install dependencies`yarn install`
+3. `expo start -w`
 
 [Upgrade snack version](https://snackager.expo.io/bundle/react-native-gifted-chat@0.15.0?bypassCache=true)
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ If you use React Navigation, additional handling may be required to account for 
 
 1. Install `yarn global add expo-cli`
 2. Install dependencies`yarn install`
-3. `expo start -w`
+3. `expo start`
 
 ### react-native-web
 


### PR DESCRIPTION
#### Motivation and context
**For new folks** there are some missing steps and could be confusing.
I was trying to setup for local development and after looking at `yarn add -g expo-cli` get the following command error:

<img src="https://p43.f3.n0.cdn.getcloudapp.com/items/geuwRDkD/Image%202020-06-30%20at%206.49.34%20PM.png?v=7c42133680c3f796a6929d8c0f4c9e25" />

Maybe this PR helps to prevent that.