### PR TITLE
[Fix] Keyboard persist taps issue after selecting image

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -391,6 +391,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   invertibleScrollViewProps: any = undefined
   _actionSheetRef: any = undefined
   _messageContainerRef?: RefObject<FlatList<IMessage>> = React.createRef()
+  _isTextInputWasFocused: boolean = false // Indicator to show if the keyboard was focused before hiding keyboard or not
   textInput?: any
 
   state = {
@@ -588,6 +589,19 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   }
 
   onKeyboardWillShow = (e: any) => {
+    // Focus the text input only if it was focused before showing keyboard
+    // This is needed in some cases (eg. showing image picker)
+    if (
+      this.textInput &&
+      this._isTextInputWasFocused &&
+      !this.textInput.isFocused()
+    ) {
+      this.textInput.focus()
+    }
+
+    // Reset the indicator since the keyboard is shown
+    this._isTextInputWasFocused = false
+
     if (this.props.isKeyboardInternallyHandled) {
       this.setIsTypingDisabled(true)
       this.setKeyboardHeight(
@@ -602,6 +616,13 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   }
 
   onKeyboardWillHide = (_e: any) => {
+    // Use condition since the `onKeyboardWillHide` may be called
+    // twice in sequence in some case (eg. showing image picker)
+    // and we expect only one event.
+    if (!this._isTextInputWasFocused) {
+      this._isTextInputWasFocused = this.textInput?.isFocused() || false
+    }
+
     if (this.props.isKeyboardInternallyHandled) {
       this.setIsTypingDisabled(true)
       this.setKeyboardHeight(0)


### PR DESCRIPTION
The issue happens during opening image picker and the text input is already focused. In this case, the text input lost its focus after opening the picker so when the picker closed we can't dismiss the keyboard by tapping on container so we need to re-focus the text input. The steps to produce the issue are in this [Video](https://www.dropbox.com/s/8impa23i6la3n66/keypersist.mp4?dl=0&raw=1) (Thanks to @xcarpentier)
