### PR TITLE
Change proptype of extraData in MessageContainer

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -131,7 +131,7 @@ export default class MessageContainer<
     inverted: PropTypes.bool,
     loadEarlier: PropTypes.bool,
     invertibleScrollViewProps: PropTypes.object,
-    extraData: PropTypes.array,
+    extraData: PropTypes.object,
     scrollToBottom: PropTypes.bool,
     scrollToBottomOffset: PropTypes.number,
     scrollToBottomComponent: PropTypes.func,


### PR DESCRIPTION
Fixes #1826. Proptypes should now line up with how extraData is consumed in MessageContainer.