### PR TITLE
Option to provide custom text inside Day/time components

### DIFF
--- a/flow-typedefs/Day.js.flow
+++ b/flow-typedefs/Day.js.flow
@@ -16,6 +16,7 @@ export type DayProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
   textStyle?: TextStyleProp,
   dateFormat?: string,
   inverted?: boolean,
+  customText?: string
 |}>
 
 export default class Day<TMessage: IMessage = IMessage> extends PureComponent<

--- a/flow-typedefs/Time.js.flow
+++ b/flow-typedefs/Time.js.flow
@@ -12,6 +12,7 @@ export type TimeProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
   containerStyle?: LeftRightStyle<ViewStyleProp>,
   timeTextStyle?: LeftRightStyle<TextStyleProp>,
   timeFormat?: string,
+  customText?: string
 |}>
 
 export default class Time<TMessage: IMessage = IMessage> extends Component<

--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -40,6 +40,7 @@ export interface DayProps<TMessage extends IMessage> {
   textStyle?: StyleProp<TextStyle>
   dateFormat?: string
   inverted?: boolean
+  customText?: string
 }
 
 export default class Day<
@@ -80,6 +81,7 @@ export default class Day<
       containerStyle,
       wrapperStyle,
       textStyle,
+      customText,
     } = this.props
 
     if (currentMessage && !isSameDay(currentMessage, previousMessage!)) {
@@ -87,7 +89,7 @@ export default class Day<
         <View style={[styles.container, containerStyle]}>
           <View style={wrapperStyle}>
             <Text style={[styles.text, textStyle]}>
-              {dayjs(currentMessage.createdAt)
+              {customText ? customText : dayjs(currentMessage.createdAt)
                 .locale(this.context.getLocale())
                 .format(dateFormat)}
             </Text>

--- a/src/Time.tsx
+++ b/src/Time.tsx
@@ -47,6 +47,7 @@ export interface TimeProps<TMessage extends IMessage> {
   containerStyle?: LeftRightStyle<ViewStyle>
   timeTextStyle?: LeftRightStyle<TextStyle>
   timeFormat?: string
+  customText?: string
 }
 
 export default class Time<
@@ -87,6 +88,7 @@ export default class Time<
       currentMessage,
       timeFormat,
       timeTextStyle,
+      customText,
     } = this.props
 
     if (!!currentMessage) {
@@ -105,7 +107,7 @@ export default class Time<
               ] as TextStyle
             }
           >
-            {dayjs(currentMessage.createdAt)
+            {customText ? customText : dayjs(currentMessage.createdAt)
               .locale(this.context.getLocale())
               .format(timeFormat)}
           </Text>


### PR DESCRIPTION
This PR adds option to pass custom text instead default behavior of Day and Time components. I have some usecases when I need to display custom message instead using default logic, like to display "just now" when createdAt + 5s > now