### PR TITLE
Add textProps to Day component

### DIFF
--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -7,6 +7,7 @@ import {
   StyleProp,
   ViewStyle,
   TextStyle,
+  TextProps,
 } from 'react-native'
 import dayjs from 'dayjs'
 
@@ -38,6 +39,7 @@ export interface DayProps<TMessage extends IMessage> {
   containerStyle?: StyleProp<ViewStyle>
   wrapperStyle?: StyleProp<ViewStyle>
   textStyle?: StyleProp<TextStyle>
+  textProps?: TextProps
   dateFormat?: string
   inverted?: boolean
 }
@@ -58,6 +60,7 @@ export default class Day<
     containerStyle: {},
     wrapperStyle: {},
     textStyle: {},
+    textProps: {},
     dateFormat: DATE_FORMAT,
   }
 
@@ -69,6 +72,7 @@ export default class Day<
     containerStyle: StylePropType,
     wrapperStyle: StylePropType,
     textStyle: StylePropType,
+    textProps: PropTypes.object,
     dateFormat: PropTypes.string,
   }
 
@@ -80,13 +84,14 @@ export default class Day<
       containerStyle,
       wrapperStyle,
       textStyle,
+      textProps,
     } = this.props
 
     if (currentMessage && !isSameDay(currentMessage, previousMessage!)) {
       return (
         <View style={[styles.container, containerStyle]}>
           <View style={wrapperStyle}>
-            <Text style={[styles.text, textStyle]}>
+            <Text style={[styles.text, textStyle]} {...textProps}>
               {dayjs(currentMessage.createdAt)
                 .locale(this.context.getLocale())
                 .format(dateFormat)}


### PR DESCRIPTION
This PR adds the ability of us passing specific props directly to the `Text` component used on `Day.tsx`. This is especially useful when we need to use something as `maxFontSizeMultiplier` for example.