### PR TITLE
Support iPhone 12 series and message layout prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "dayjs": "^1.8.26",
     "prop-types": "^15.7.2",
     "react-native-communications": "^2.2.1",
-    "react-native-iphone-x-helper": "^1.2.1",
+    "react-native-iphone-x-helper": "^1.3.1",
     "react-native-lightbox": "^0.8.1",
     "react-native-parsed-text": "0.0.22",
     "react-native-typing-animation": "^0.1.7",

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { View, StyleSheet, ViewStyle } from 'react-native'
+import { View, StyleSheet, ViewStyle, LayoutChangeEvent } from 'react-native'
 
 import Avatar from './Avatar'
 import Bubble from './Bubble'
@@ -49,6 +49,7 @@ export interface MessageProps<TMessage extends IMessage> {
     props: MessageProps<IMessage>,
     nextProps: MessageProps<IMessage>,
   ): boolean
+  onMessageLayout?(event: LayoutChangeEvent): void
 }
 
 export default class Message<
@@ -68,6 +69,7 @@ export default class Message<
     showUserAvatar: false,
     inverted: true,
     shouldUpdateMessage: undefined,
+    onMessageLayout: undefined,
   }
 
   static propTypes = {
@@ -87,6 +89,7 @@ export default class Message<
       right: StylePropType,
     }),
     shouldUpdateMessage: PropTypes.func,
+    onMessageLayout: PropTypes.func,
   }
 
   shouldComponentUpdate(nextProps: MessageProps<TMessage>) {
@@ -118,7 +121,7 @@ export default class Message<
 
   renderDay() {
     if (this.props.currentMessage && this.props.currentMessage.createdAt) {
-      const { containerStyle, ...props } = this.props
+      const { containerStyle, onMessageLayout, ...props } = this.props
       if (this.props.renderDay) {
         return this.props.renderDay(props)
       }
@@ -128,7 +131,7 @@ export default class Message<
   }
 
   renderBubble() {
-    const { containerStyle, ...props } = this.props
+    const { containerStyle, onMessageLayout, ...props } = this.props
     if (this.props.renderBubble) {
       return this.props.renderBubble(props)
     }
@@ -137,7 +140,7 @@ export default class Message<
   }
 
   renderSystemMessage() {
-    const { containerStyle, ...props } = this.props
+    const { containerStyle, onMessageLayout, ...props } = this.props
 
     if (this.props.renderSystemMessage) {
       return this.props.renderSystemMessage(props)
@@ -167,16 +170,22 @@ export default class Message<
       return null
     }
 
-    const { containerStyle, ...props } = this.props
+    const { containerStyle, onMessageLayout, ...props } = this.props
     return <Avatar {...props} />
   }
 
   render() {
-    const { currentMessage, nextMessage, position, containerStyle } = this.props
+    const {
+      currentMessage,
+      onMessageLayout,
+      nextMessage,
+      position,
+      containerStyle,
+    } = this.props
     if (currentMessage) {
       const sameUser = isSameUser(currentMessage, nextMessage!)
       return (
-        <View>
+        <View onLayout={onMessageLayout}>
           {this.renderDay()}
           {currentMessage.system ? (
             this.renderSystemMessage()

--- a/yarn.lock
+++ b/yarn.lock
@@ -5996,10 +5996,10 @@ react-native-communications@^2.2.1:
   resolved "https://registry.yarnpkg.com/react-native-communications/-/react-native-communications-2.2.1.tgz#7883b56b20a002eeb790c113f8616ea8692ca795"
   integrity sha1-eIO1ayCgAu63kMET+GFuqGksp5U=
 
-react-native-iphone-x-helper@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
-  integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+react-native-iphone-x-helper@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
+  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
 react-native-lightbox@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
- Update `react-native-iphone-x-helper` to support iPhone 12 series devices
- Add `onMessageLayout` prop to get the message layout. This is useful if we need to implement scrolling to specific message.