### PR TITLE
`LeftRightStyle` should be an optional param

### DIFF
--- a/src/Models.ts
+++ b/src/Models.ts
@@ -26,8 +26,8 @@ export { TimeProps } from './Time'
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
 export interface LeftRightStyle<T> {
-  left: StyleProp<T>
-  right: StyleProp<T>
+  left?: StyleProp<T>
+  right?: StyleProp<T>
 }
 type renderFunction = (x: any) => JSX.Element
 export interface User {


### PR DESCRIPTION
I found the issue when i want to change just only one param it will give error so
i just changed it to `?` optional `param` of  

```
export interface LeftRightStyle<T> {
    left?: StyleProp<T>;
    right?: StyleProp<T>;
}
```


solved #1984 