### PR TITLE
* fix infiniteScroll issue #1928

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -142,6 +142,7 @@ export default class MessageContainer<
 
   state = {
     showScrollBottom: false,
+    hasScrolled: false,
   }
 
   renderTypingIndicator = () => {
@@ -198,18 +199,18 @@ export default class MessageContainer<
     const { scrollToBottomOffset } = this.props
     if (this.props.inverted) {
       if (contentOffsetY > scrollToBottomOffset!) {
-        this.setState({ showScrollBottom: true })
+        this.setState({ showScrollBottom: true, hasScrolled: true })
       } else {
-        this.setState({ showScrollBottom: false })
+        this.setState({ showScrollBottom: false, hasScrolled: true })
       }
     } else {
       if (
         contentOffsetY < scrollToBottomOffset! &&
         contentSizeHeight - layoutMeasurementHeight > scrollToBottomOffset!
       ) {
-        this.setState({ showScrollBottom: true })
+        this.setState({ showScrollBottom: true, hasScrolled: true })
       } else {
-        this.setState({ showScrollBottom: false })
+        this.setState({ showScrollBottom: false, hasScrolled: true })
       }
     }
   }
@@ -316,7 +317,7 @@ export default class MessageContainer<
     } = this.props
     if (
       infiniteScroll &&
-      distanceFromEnd > 0 &&
+      (this.state.hasScrolled || distanceFromEnd > 0) &&
       distanceFromEnd <= 100 &&
       loadEarlier &&
       onLoadEarlier &&


### PR DESCRIPTION
Fix for `infiniteScroll` issue #1928

Run the `onLoadEarlier` even when hitting the edge, but not when initially opening the chat (user scroll has to happen first)