### PR TITLE
Fixed type definition to allow `null` as acceptable value for `render…

### DIFF
--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -52,7 +52,7 @@ export interface AvatarProps<TMessage extends IMessage> {
   imageStyle?: LeftRightStyle<ImageStyle>
   containerStyle?: LeftRightStyle<ViewStyle>
   textStyle?: TextStyle
-  renderAvatar?(props: Omit<AvatarProps<TMessage>, 'renderAvatar'>): ReactNode
+  renderAvatar?: ((props: Omit<AvatarProps<TMessage>, 'renderAvatar'>) => ReactNode) | null
   onPressAvatar?(user: User): void
   onLongPressAvatar?(user: User): void
 }

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -158,7 +158,7 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* Custom "Load earlier messages" button */
   renderLoadEarlier?(props: LoadEarlier['props']): React.ReactNode
   /* Custom message avatar; set to null to not render any avatar for the message */
-  renderAvatar?(props: Avatar<TMessage>['props']): React.ReactNode | null
+  renderAvatar?: ((props: Avatar<TMessage>['props']) => React.ReactNode) | null
   /* Custom message bubble */
   renderBubble?(props: Bubble<TMessage>['props']): React.ReactNode
   /*Custom system message */

--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -44,7 +44,7 @@ export interface MessageProps<TMessage extends IMessage> {
   renderBubble?(props: Bubble['props']): React.ReactNode
   renderDay?(props: Day['props']): React.ReactNode
   renderSystemMessage?(props: SystemMessage['props']): React.ReactNode
-  renderAvatar?(props: Avatar['props']): React.ReactNode
+  renderAvatar?: ((props: Avatar['props']) => React.ReactNode) | null
   shouldUpdateMessage?(
     props: MessageProps<IMessage>,
     nextProps: MessageProps<IMessage>,


### PR DESCRIPTION
It is documented that

  > `renderAvatar` (Function) - Custom message avatar; set to `null` to not render any avatar for the message

  Since `renderAvatar={null}` used to show type error and so I had used `renderAvatar={() => null}` instead thinking that it'd reflect the same behavior.
  As I got back to the code a week later, the bad trip began with this:

![rn-gifted-chat-bug](https://user-images.githubusercontent.com/26021293/112675789-9833da00-8e8d-11eb-8c81-3bf5bb281386.JPG)

  1. In `Message.tsx`, `this.renderAvatar()` is called. Since user's avatar is acceptable to be an `undefined` value, it proceeds ahead by calling `return <Avatar {...props} />` for other user's messages.

  2. After `renderAvatar` is called, in the `render()` function of `Avatar`, this check causes all the trouble:
  `if (renderAvatar === null) { return null;}`

  3. Thereafter, `GiftedAvatar` is rendered with default `null` values for all these messages except the last one. Note that when avatar is `undefined`, `renderInitials` is used in `GiftedAvatar` to show avatar name initials and hence `undefined` is an expected value here. That's why `renderAvatar` prop for `GiftedChat` must be defined.

  4. For the last message by the other use in this sequence of messages, `renderAvatar()` function is called in `Avatar.js` itself, where my function `this.props.renderAvatar` being present renders a `null` React element.

  What worked for me: **Fixed type definitions for `renderAvatar` to allow `null` as an accepted value.**
 