### PR TITLE
fix iOS scroll bounce

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -317,7 +317,7 @@ export default class MessageContainer<
     } = this.props
     if (
       infiniteScroll &&
-      (this.state.hasScrolled || distanceFromEnd > 0) &&
+      this.state.hasScrolled &&
       distanceFromEnd <= 100 &&
       loadEarlier &&
       onLoadEarlier &&


### PR DESCRIPTION
There will be a bounce on fast scrolling on iOS, and the distance may be less than 0 at this time.

Related issues: #2048, #2091