### PR TITLE
chore(use-memo-one): update to support react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-native-parsed-text": "0.0.22",
     "react-native-safe-area-context": "4.2.4",
     "react-native-typing-animation": "0.1.7",
-    "use-memo-one": "1.1.1",
+    "use-memo-one": "1.1.2",
     "uuid": "3.4.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7800,10 +7800,10 @@ urix@^0.1.0:
   resolved "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-use-memo-one@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz"
-  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
+use-memo-one@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
+  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
 
 use-subscription@^1.0.0:
   version "1.5.1"


### PR DESCRIPTION
Updates use-memo-one to latest (1.1.2) which supports react 17

Closes GH-2200