### PR TITLE
Support renderUsername

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ interface QuickReplies {
 - **`onLongPress`** _(Function(`context`, `message`))_ - Callback when a message bubble is long-pressed; default is to show an ActionSheet with "Copy Text" (see [example using `showActionSheetWithOptions()`](https://github.com/FaridSafi/react-native-gifted-chat/blob/master@%7B2017-09-25%7D/src/Bubble.js#L96-L119))
 - **`inverted`** _(Bool)_ - Reverses display order of `messages`; default is `true`
 - **`renderUsernameOnMessage`** _(Bool)_ - Indicate whether to show the user's username inside the message bubble; default is `false`
+- **`renderUsername`** _(Function)_ - Custom Username container
 - **`renderMessage`** _(Function)_ - Custom message container
 - **`renderMessageText`** _(Function)_ - Custom message text
 - **`renderMessageImage`** _(Function)_ - Custom message image

--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -455,10 +455,13 @@ export default class Bubble<
   }
 
   renderUsername() {
-    const { currentMessage, user } = this.props
+    const { currentMessage, user, renderUsername } = this.props
     if (this.props.renderUsernameOnMessage && currentMessage) {
       if (user && currentMessage.user._id === user._id) {
         return null
+      }
+      if (renderUsername) {
+        return renderUsername(currentMessage.user)
       }
       return (
         <View style={styles.content.usernameView}>

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -171,6 +171,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   onPress?(context: any, message: TMessage): void
   /* Callback when a message bubble is long-pressed; default is to show an ActionSheet with "Copy Text" (see example using showActionSheetWithOptions()) */
   onLongPress?(context: any, message: TMessage): void
+  /*Custom Username container */
+  renderUsername?(user: User): React.ReactNode
   /* Reverses display order of messages; default is true */
   /*Custom message container */
   renderMessage?(message: Message<TMessage>['props']): React.ReactNode
@@ -261,6 +263,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     renderBubble: null,
     renderSystemMessage: null,
     onLongPress: null,
+    renderUserName: null,
     renderMessage: null,
     renderMessageText: null,
     renderMessageImage: null,


### PR DESCRIPTION
We have the prop `renderUsername` but didn't use it before and we can't custom username's view. So I just return the `renderUsername` to allow custom username's view