### PR TITLE
Fix: QuickReplies component is returning null before a react hook & breaking rules of hooks.

### DIFF
--- a/src/QuickReplies.tsx
+++ b/src/QuickReplies.tsx
@@ -91,10 +91,6 @@ export function QuickReplies({
     return false
   }, [currentMessage, nextMessage])
 
-  if (!shouldComponentDisplay) {
-    return null
-  }
-
   const handlePress = useCallbackOne(
     (reply: Reply) => () => {
       if (currentMessage) {
@@ -129,6 +125,10 @@ export function QuickReplies({
         messageId: currentMessage!._id,
       })),
     )
+  }
+
+  if (!shouldComponentDisplay) {
+    return null
   }
 
   return (


### PR DESCRIPTION
- Return null when !shouldComponentDisplay after the useCallbackOne hook
- Closes #2216 