### PR TITLE
fix(Composer): fix typo preventing onInputSizeChanged from being called

### DIFF
--- a/src/Composer.tsx
+++ b/src/Composer.tsx
@@ -78,8 +78,8 @@ export function Composer({
       if (
         !layoutRef ||
         (layoutRef.current &&
-          (layoutRef.current.width !== layoutRef.current.width ||
-            layoutRef.current.height !== layoutRef.current.height))
+          (layoutRef.current.width !== layout.width ||
+            layoutRef.current.height !== layout.height))
       ) {
         layoutRef.current = layout
         onInputSizeChanged(layout)


### PR DESCRIPTION
Somehow it seems during a refactor the wrong properties were used.

https://github.com/FaridSafi/react-native-gifted-chat/blame/260902effd61b8cbf8b04aa8e4f3bb817f5f970d/src/Composer.tsx#L92-L93