### PR TITLE
Problem with minComposerHeight.

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -23,6 +23,8 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
 })
 
+const findStep = step => message => message._id === step
+
 const user = {
   _id: 1,
   name: 'Developer',
@@ -106,7 +108,6 @@ export default class App extends Component {
   botSend = (step = 0) => {
     const newMessage = (messagesData as IMessage[])
       .reverse()
-      // .filter(filterBotMessages)
       .find(findStep(step))
     if (newMessage) {
       this.setState((previousState: any) => ({

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -23,10 +23,6 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
 })
 
-const filterBotMessages = message =>
-  !message.system && message.user && message.user._id && message.user._id === 2
-const findStep = step => message => message._id === step
-
 const user = {
   _id: 1,
   name: 'Developer',

--- a/example/example-expo/CustomActions.tsx
+++ b/example/example-expo/CustomActions.tsx
@@ -70,6 +70,7 @@ export default class CustomActions extends React.Component {
 
 const styles = StyleSheet.create({
   container: {
+    marginTop: 10,
     width: 26,
     height: 26,
     marginLeft: 10,

--- a/flow-typedefs/GiftedChat.js.flow
+++ b/flow-typedefs/GiftedChat.js.flow
@@ -128,7 +128,6 @@ export type GiftedChatProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
 export type GiftedChatState<TMessage: IMessage = IMessage> = {|
   isInitialized: boolean,
   composerHeight?: number,
-  messagesContainerHeight?: number | AnimatedValue,
   typingDisabled: boolean,
   text?: string,
   messages?: Array<TMessage>,

--- a/src/Composer.tsx
+++ b/src/Composer.tsx
@@ -9,6 +9,7 @@ import {
 import { MIN_COMPOSER_HEIGHT, DEFAULT_PLACEHOLDER } from './Constant'
 import Color from './Color'
 import { StylePropType } from './utils'
+import { useChatContext } from './GiftedChatContext'
 
 const styles = StyleSheet.create({
   textInput: {
@@ -62,7 +63,8 @@ export function Composer({
   textInputProps = {},
   textInputStyle,
 }: ComposerProps): React.ReactElement {
-  const [composerHeight, setComposerHeight] = React.useState(MIN_COMPOSER_HEIGHT)
+  const chatContext = useChatContext()
+  const [composerHeight, setComposerHeight] = React.useState(chatContext.minComposerHeight)
 
   return (
     <TextInput
@@ -71,7 +73,7 @@ export function Composer({
       accessibilityLabel={placeholder}
       onContentSizeChange={(e) => {
         const min = Math.min(e.nativeEvent.contentSize.height, 100)
-        const max = Math.max(min, MIN_COMPOSER_HEIGHT ?? 0)
+        const max = Math.max(min, chatContext.minComposerHeight)
         setComposerHeight(max)
       }}
       placeholder={placeholder}

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -564,8 +564,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     )
   }
 
-
-
   safeAreaSupport = (bottomOffset?: number) => {
     return bottomOffset != null ? bottomOffset : 1
   }

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -827,6 +827,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
             value={{
               actionSheet,
               getLocale,
+              minComposerHeight: this.props.minComposerHeight ?? MIN_COMPOSER_HEIGHT ?? 0,
             }}
           >
 

--- a/src/GiftedChatContext.ts
+++ b/src/GiftedChatContext.ts
@@ -1,8 +1,10 @@
 import * as React from 'react'
+import { MIN_COMPOSER_HEIGHT } from './Constant'
 
 export interface IGiftedChatContext {
   actionSheet(): { showActionSheetWithOptions: (option?: any, cb?: any) => any }
   getLocale(): string
+  minComposerHeight: number
 }
 
 export const GiftedChatContext = React.createContext<IGiftedChatContext>({
@@ -10,6 +12,7 @@ export const GiftedChatContext = React.createContext<IGiftedChatContext>({
   actionSheet: () => ({
     showActionSheetWithOptions: () => {},
   }),
+  minComposerHeight: MIN_COMPOSER_HEIGHT || 0
 })
 
 export const useChatContext = () => React.useContext(GiftedChatContext)

--- a/src/InputToolbar.tsx
+++ b/src/InputToolbar.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
-import { StyleSheet, View, Keyboard, StyleProp, ViewStyle } from 'react-native'
+import React from 'react'
+import { StyleSheet, View, StyleProp, ViewStyle } from 'react-native'
 
 import { Composer, ComposerProps } from './Composer'
 import { Send, SendProps } from './Send'
@@ -11,6 +11,7 @@ import { IMessage } from './Models'
 
 const styles = StyleSheet.create({
   container: {
+    flexGrow : 0,
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: Color.defaultColor,
     backgroundColor: Color.white,
@@ -20,7 +21,7 @@ const styles = StyleSheet.create({
   },
   primary: {
     flexDirection: 'row',
-    alignItems: 'flex-end',
+    alignItems: 'center',
   },
   accessory: {
     height: 44,
@@ -43,22 +44,6 @@ export interface InputToolbarProps<TMessage extends IMessage> {
 export function InputToolbar<TMessage extends IMessage = IMessage>(
   props: InputToolbarProps<TMessage>,
 ) {
-  const [position, setPosition] = useState('absolute')
-  useEffect(() => {
-    const keyboardWillShowListener = Keyboard.addListener(
-      'keyboardWillShow',
-      () => setPosition('relative'),
-    )
-    const keyboardWillHideListener = Keyboard.addListener(
-      'keyboardWillHide',
-      () => setPosition('absolute'),
-    )
-    return () => {
-      keyboardWillShowListener?.remove()
-      keyboardWillHideListener?.remove()
-    }
-  }, [])
-
   const { containerStyle, ...rest } = props
   const {
     renderActions,
@@ -69,7 +54,7 @@ export function InputToolbar<TMessage extends IMessage = IMessage>(
   } = rest
 
   return (
-    <View style={[styles.container, { position }, containerStyle] as ViewStyle}>
+    <View style={[styles.container, containerStyle] as ViewStyle}>
       <View style={[styles.primary, props.primaryStyle]}>
         {renderActions?.(rest) ||
           (onPressActionButton && <Actions {...rest} />)}


### PR DESCRIPTION
The minComposerHeight prop is not working correctly for me. Seems that having the keyboard hidden/shown causes the message list to be placed below the message container.
Also, event with multiline prop I am not able to scroll more than 1 line of message at the time.
I started looking at the code, and seems that the current approach to keyboard hiding is using absolute and relative positioning. I was wondering, if perhaps it would be cleaner to use flex based containers. This would allow for the input to grow as needed. It also works correctly with the prop now supplied.

Please let me know what you think

![Simulator Screen Recording - iPhone 13 Pro - 2022-06-12 at 16 34 42](https://user-images.githubusercontent.com/675615/173238342-35fec93f-d31c-4f41-9da4-85e5babe01b0.gif)

