### PR TITLE
Fix: allow custom message type TMessage for quickReply props similar to MessageImage,  etc.

### DIFF
--- a/flow-typedefs/Bubble.js.flow
+++ b/flow-typedefs/Bubble.js.flow
@@ -59,7 +59,7 @@ export type BubbleProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
   renderTicks?: TMessage => React.Node,
   renderUsername?: () => React.Node,
   renderQuickReplySend?: () => React.Node,
-  renderQuickReplies?: QuickRepliesProps => React.Node,
+  renderQuickReplies?: (QuickRepliesProps<TMessage>) => React.Node,
 |}>
 
 export default class Bubble<

--- a/flow-typedefs/GiftedChat.js.flow
+++ b/flow-typedefs/GiftedChat.js.flow
@@ -117,7 +117,7 @@ export type GiftedChatProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
   onInputTextChanged?: (text: string) => void,
   parsePatterns?: () => React.Node,
   onQuickReply?: (Array<Reply>) => void,
-  renderQuickReplies?: QuickRepliesProps => React.Node,
+  renderQuickReplies?: (QuickRepliesProps<TMessage>) => React.Node,
   renderQuickReplySend?: () => React.Node,
   shouldUpdateMessage?: (
     props: MessageProps<TMessage>,

--- a/flow-typedefs/QuickReplies.js.flow
+++ b/flow-typedefs/QuickReplies.js.flow
@@ -3,9 +3,9 @@ import * as React from 'react'
 import type { IMessage, Reply } from './types'
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet'
 
-export type QuickRepliesProps = $ReadOnly<{|
-  nextMessage?: IMessage,
-  currentMessage?: IMessage,
+export type QuickRepliesProps<TMessage: IMessage = IMessage> = $ReadOnly<{|
+  nextMessage?: TMessage,
+  currentMessage?: TMessage,
   color?: string,
   sendText?: string,
   quickReplyStyle?: ViewStyleProp,

--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -161,7 +161,9 @@ export interface BubbleProps<TMessage extends IMessage> {
   renderTicks?(currentMessage: TMessage): React.ReactNode
   renderUsername?(): React.ReactNode
   renderQuickReplySend?(): React.ReactNode
-  renderQuickReplies?(quickReplies: QuickRepliesProps): React.ReactNode
+  renderQuickReplies?(
+    quickReplies: QuickRepliesProps<TMessage>,
+  ): React.ReactNode
 }
 
 export default class Bubble<
@@ -341,14 +343,12 @@ export default class Bubble<
       }
       return (
         <QuickReplies
-          {...{
-            currentMessage,
-            onQuickReply,
-            nextMessage,
-            renderQuickReplySend,
-            quickReplyStyle,
-            quickReplyTextStyle,
-          }}
+          currentMessage={currentMessage}
+          onQuickReply={onQuickReply}
+          renderQuickReplySend={renderQuickReplySend}
+          quickReplyStyle={quickReplyStyle}
+          quickReplyTextStyle={quickReplyTextStyle}
+          nextMessage={nextMessage}
         />
       )
     }

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -211,7 +211,9 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* Custom parse patterns for react-native-parsed-text used to linking message content (like URLs and phone numbers) */
   parsePatterns?(linkStyle: TextStyle): any
   onQuickReply?(replies: Reply[]): void
-  renderQuickReplies?(quickReplies: QuickRepliesProps): React.ReactNode
+  renderQuickReplies?(
+    quickReplies: QuickRepliesProps<TMessage>,
+  ): React.ReactNode
   renderQuickReplySend?(): React.ReactNode
   /* Scroll to bottom custom component */
   scrollToBottomComponent?(): React.ReactNode

--- a/src/QuickReplies.tsx
+++ b/src/QuickReplies.tsx
@@ -45,9 +45,9 @@ const styles = StyleSheet.create({
   },
 })
 
-export interface QuickRepliesProps {
-  nextMessage?: IMessage
-  currentMessage?: IMessage
+export interface QuickRepliesProps<TMessage extends IMessage = IMessage> {
+  nextMessage?: TMessage
+  currentMessage?: TMessage
   color?: string
   sendText?: string
   quickReplyStyle?: StyleProp<ViewStyle>
@@ -71,7 +71,7 @@ export function QuickReplies({
   onQuickReply,
   sendText = 'Send',
   renderQuickReplySend,
-}: QuickRepliesProps) {
+}: QuickRepliesProps<IMessage>) {
   const { type } = currentMessage!.quickReplies!
   const [replies, setReplies] = useState<Reply[]>([])
 


### PR DESCRIPTION
- Currently we can not pass custom message to the QuickReply component due to it type constraint allowing it to use IMessage only.
- This PR enables use of custom message type TMessage similar to other components like MessageImage & also makes it consistent.