### PR TITLE
upgrade react-native-safe-area-context dependency to fix issue with expo SDK 46

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test": "TZ=Europe/Paris jest --no-watchman",
     "test:watch": "TZ=Europe/Paris jest --watch",
     "test:coverage": "TZ=Europe/Paris jest --coverage",
-    "prepare": "yarn lint && yarn build && yarn test",
+    "prepublishOnly": "yarn lint && yarn build && yarn test",
+    "prepare": "yarn build",
     "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{ts,tsx}\""
   },
   "devDependencies": {
@@ -73,7 +74,7 @@
     "react-native-iphone-x-helper": "1.3.1",
     "react-native-lightbox-v2": "0.9.0",
     "react-native-parsed-text": "0.0.22",
-    "react-native-safe-area-context": "^4.3.1",
+    "react-native-safe-area-context": "4.3.1",
     "react-native-typing-animation": "0.1.7",
     "use-memo-one": "1.1.2",
     "uuid": "3.4.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-native-iphone-x-helper": "1.3.1",
     "react-native-lightbox-v2": "0.9.0",
     "react-native-parsed-text": "0.0.22",
-    "react-native-safe-area-context": "^4.2.4",
+    "react-native-safe-area-context": "^4.3.1",
     "react-native-typing-animation": "0.1.7",
     "use-memo-one": "1.1.2",
     "uuid": "3.4.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "TZ=Europe/Paris jest --no-watchman",
     "test:watch": "TZ=Europe/Paris jest --watch",
     "test:coverage": "TZ=Europe/Paris jest --coverage",
-    "prepublishOnly": "yarn lint && yarn build && yarn test",
+    "prepublish": "yarn lint && yarn build && yarn test",
     "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{ts,tsx}\""
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:watch": "TZ=Europe/Paris jest --watch",
     "test:coverage": "TZ=Europe/Paris jest --coverage",
     "prepublish": "yarn lint && yarn build && yarn test",
+    "prepack": "yarn lint && yarn build && yarn test",
     "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{ts,tsx}\""
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "test": "TZ=Europe/Paris jest --no-watchman",
     "test:watch": "TZ=Europe/Paris jest --watch",
     "test:coverage": "TZ=Europe/Paris jest --coverage",
-    "prepublish": "yarn lint && yarn build && yarn test",
-    "prepack": "yarn lint && yarn build && yarn test",
+    "prepare": "yarn lint && yarn build && yarn test",
     "prettier": "./node_modules/.bin/prettier --write \"src/**/*.{ts,tsx}\""
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6698,10 +6698,10 @@ react-native-parsed-text@0.0.22:
   dependencies:
     prop-types "^15.7.x"
 
-react-native-safe-area-context@4.2.4:
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.2.4.tgz"
-  integrity sha512-OOX+W2G4YYufvryonn6Kw6YnyT8ZThkxPHZBD04NLHaZmicUaaDVII/PZ3M5fD1o5N62+T+8K4bCS5Un2ggvkA==
+react-native-safe-area-context@^4.3.1:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"
+  integrity sha512-xwsloGLDUzeTN40TIh4Te/zRePSnBAuWlLIiEW3RYE9gHHYslqQWpfK7N24SdAQEH3tHZ+huoYNjo2GQJO/vnQ==
 
 react-native-typing-animation@0.1.7:
   version "0.1.7"


### PR DESCRIPTION
fix react-native-safe-area-context dependency to same as the required of expo SDK 46 from ^4.2.4 to ^4.3.1