### PR TITLE
Add `renderUnread` prop

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -168,7 +168,7 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /*Custom system message */
   renderSystemMessage?(props: SystemMessageProps<TMessage>): React.ReactNode
   /* Render an unread box component BEFORE the message with this id */
-  renderUnread?(messageID: TMessage["_id"]): React.ReactNode;
+  renderUnread?(messageID: TMessage['_id']): React.ReactNode
   /* Callback when a message bubble is pressed; default is to do nothing */
   onPress?(context: any, message: TMessage): void
   /* Callback when a message bubble is long-pressed; default is to show an ActionSheet with "Copy Text" (see example using showActionSheetWithOptions()) */

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -89,7 +89,7 @@ export interface MessageContainerProps<TMessage extends IMessage> {
   onQuickReply?(replies: Reply[]): void
   infiniteScroll?: boolean
   isLoadingEarlier?: boolean
-  renderUnread?(messageID: TMessage["_id"]): React.ReactNode;
+  renderUnread?(messageID: TMessage['_id']): React.ReactNode
 }
 
 interface State {


### PR DESCRIPTION
This PR adds the ability to show a "x unread messages" component above the unread messages. It also allows to show other data as well, you can show whatever you want!