### PR TITLE
Fixes null type for renderAvatar prop

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -163,7 +163,7 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* Custom "Load earlier messages" button */
   renderLoadEarlier?(props: LoadEarlierProps): React.ReactNode
   /* Custom message avatar; set to null to not render any avatar for the message */
-  renderAvatar?(props: AvatarProps<TMessage>): React.ReactNode | null
+  renderAvatar?: null | ((props: AvatarProps<TMessage>) => React.ReactNode)
   /* Custom message bubble */
   renderBubble?(props: Bubble<TMessage>['props']): React.ReactNode
   /*Custom system message */


### PR DESCRIPTION
The `renderAvatar` prop must accept `null` as value to prevent issues like #2274.

`null` was included in the union type of the `renderAvatar` return value, and thus was not caught by [this TS rule](https://github.com/microsoft/TypeScript/pull/39570)