### PR TITLE
Add `imageSourceProps` to `MessageImage`

### DIFF
--- a/src/MessageImage.tsx
+++ b/src/MessageImage.tsx
@@ -62,7 +62,7 @@ export function MessageImage<TMessage extends IMessage = IMessage>({
         <Image
           {...imageProps}
           style={[styles.image, imageStyle]}
-          source={{ uri: currentMessage.image, ...imageSourceProps }}
+          source={{ ...imageSourceProps, uri: currentMessage.image }}
         />
       </Lightbox>
     </View>

--- a/src/MessageImage.tsx
+++ b/src/MessageImage.tsx
@@ -8,6 +8,7 @@ import {
   ViewStyle,
   StyleProp,
   ImageStyle,
+  ImageURISource,
 } from 'react-native'
 // TODO: support web
 import Lightbox, { LightboxProps } from 'react-native-lightbox-v2'
@@ -32,6 +33,7 @@ const styles = StyleSheet.create({
 export interface MessageImageProps<TMessage extends IMessage> {
   currentMessage?: TMessage
   containerStyle?: StyleProp<ViewStyle>
+  imageSourceProps?: Partial<ImageURISource>
   imageStyle?: StyleProp<ImageStyle>
   imageProps?: Partial<ImageProps>
   lightboxProps?: LightboxProps
@@ -41,6 +43,7 @@ export function MessageImage<TMessage extends IMessage = IMessage>({
   containerStyle,
   lightboxProps = {},
   imageProps = {},
+  imageSourceProps = {},
   imageStyle,
   currentMessage,
 }: MessageImageProps<TMessage>) {
@@ -59,7 +62,7 @@ export function MessageImage<TMessage extends IMessage = IMessage>({
         <Image
           {...imageProps}
           style={[styles.image, imageStyle]}
-          source={{ uri: currentMessage.image }}
+          source={{ uri: currentMessage.image, ...imageSourceProps }}
         />
       </Lightbox>
     </View>
@@ -69,6 +72,7 @@ export function MessageImage<TMessage extends IMessage = IMessage>({
 MessageImage.propTypes = {
   currentMessage: PropTypes.object,
   containerStyle: StylePropType,
+  imageSourceProps: PropTypes.object,
   imageStyle: StylePropType,
   imageProps: PropTypes.object,
   lightboxProps: PropTypes.object,


### PR DESCRIPTION
There is currently no way to add additional headers to the image shown in `MessageImage`. This can be an issue if you need to add credentials to the header when making a request, for instance.

Usage: 

```tsx
<MessageImage
    {...props}
    imageSourceProps={{
        headers: {
            Authorization: `Bearer ${authToken}`
        }
    }}
/>
```