### PR TITLE
Updated to use-memo-one for supporting react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-native-parsed-text": "0.0.22",
     "react-native-safe-area-context": "4.4.1",
     "react-native-typing-animation": "0.1.7",
-    "use-memo-one": "1.1.2",
+    "use-memo-one": "1.1.3",
     "uuid": "3.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumped `use-memo-one` to 1.1.3, which adds support for React 18