### PR TITLE
Add wrapInSafeArea prop to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ interface QuickReplies {
 - **`extraData`** _(Object)_ - Extra props for re-rendering FlatList on demand. This will be useful for rendering footer etc.
 - **`minComposerHeight`** _(Object)_ - Custom min-height of the composer.
 - **`maxComposerHeight`** _(Object)_ - Custom max height of the composer.
-
+* **`wrapInSafeArea`** _(Bool)_ - Wrap GiftedChat in a [SafeAreaView](https://reactnative.dev/docs/safeareaview). (Default is true).
 * **`scrollToBottom`** _(Bool)_ - Enables the scroll to bottom Component (Default is false)
 * **`scrollToBottomComponent`** _(Function)_ - Custom Scroll To Bottom Component container
 * **`scrollToBottomOffset`** _(Integer)_ - Custom Height Offset upon which to begin showing Scroll To Bottom Component (Default is 200)


### PR DESCRIPTION
I use gifted chat in a component that already handles safe areas, after about an hour of trying to figure out why gifted chat had a strange space under the input bar I went digging through the code and found the `wrapInSafeArea` prop.

I thought I'd add it to the readme to help others like me in the future :)