### PR TITLE
fix: ⚡ limit rerenders

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -411,6 +411,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   _messageContainerRef?: RefObject<FlatList<IMessage>> = React.createRef()
   _isTextInputWasFocused: boolean = false
   textInput?: any
+  _emptyArray = [] as TMessage[]
 
   state = {
     isInitialized: false, // initialization will calculate maxHeight before rendering the chat
@@ -435,10 +436,9 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
   }
 
   componentDidMount() {
-    const { messages, text } = this.props
+    const { text } = this.props
     this.setIsMounted(true)
     this.initLocale()
-    this.setMessages(messages || [])
     this.setTextFromProp(text)
   }
 
@@ -448,10 +448,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
 
   componentDidUpdate(prevProps: GiftedChatProps<TMessage> = {}) {
     const { messages, text, inverted } = this.props
-
-    if (this.props !== prevProps) {
-      this.setMessages(messages || [])
-    }
 
     if (
       inverted === false &&
@@ -493,14 +489,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       return fallback
     }
     return this.props.text
-  }
-
-  setMessages(messages: TMessage[]) {
-    this.setState({ messages })
-  }
-
-  getMessages() {
-    return this.state.messages
   }
 
   setMaxHeight(height: number) {
@@ -699,7 +687,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
         <MessageContainer<TMessage>
           {...messagesContainerProps}
           invertibleScrollViewProps={this.invertibleScrollViewProps}
-          messages={this.getMessages()}
+          messages={this.props.messages || this._emptyArray}
           forwardRef={this._messageContainerRef}
           isTyping={this.props.isTyping}
         />

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -147,6 +147,7 @@ export default class MessageContainer<
     showScrollBottom: false,
     hasScrolled: false,
   }
+  _extraData = [undefined, undefined]
 
   renderTypingIndicator = () => {
     if (Platform.OS === 'web') {
@@ -335,6 +336,12 @@ export default class MessageContainer<
 
   render() {
     const { inverted } = this.props
+    if (
+      this._extraData[0] !== this.props.extraData ||
+      this._extraData[1] !== this.props.isTyping
+    ) {
+      this._extraData = [this.props.extraData, this.props.isTyping]
+    }
     return (
       <View
         style={
@@ -343,7 +350,7 @@ export default class MessageContainer<
       >
         <FlatList
           ref={this.props.forwardRef}
-          extraData={[this.props.extraData, this.props.isTyping]}
+          extraData={this._extraData}
           keyExtractor={this.keyExtractor}
           enableEmptySections
           automaticallyAdjustContentInsets={false}


### PR DESCRIPTION
Two modifications : 
=> Do not use setState to manage messages as it implies 2 renders instead of 1
=> Manage extraData so that every MessageContainer render does not create a full re-render of the flatlist


Tested it on a react-native and react-native-web application applying a patch-package