### PR TITLE
Fixed react-native-safe-area-context Dependency (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-native-iphone-x-helper": "1.3.1",
     "react-native-lightbox-v2": "0.9.0",
     "react-native-parsed-text": "0.0.22",
-    "react-native-safe-area-context": "4.4.1",
+    "react-native-safe-area-context": "^4.4.1",
     "react-native-typing-animation": "0.1.7",
     "use-memo-one": "1.1.2",
     "uuid": "3.4.0"


### PR DESCRIPTION
[This PR](https://github.com/FaridSafi/react-native-gifted-chat/pull/2234) added a solution but i think it lost for some reason.

pre fix:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1262011/221391945-e342a945-7825-4253-98da-9e85d1ca7e3f.png">

post fix:
<img width="358" alt="image" src="https://user-images.githubusercontent.com/1262011/221391953-66fd3d7b-3c30-4de9-abeb-4400741e06b8.png">

