### PR TITLE
ref!: remove react-native-safe-area-context dependency

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons'
 import * as Linking from 'expo-linking'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import AppLoading from 'expo-app-loading'
 import React, { Component } from 'react'
 import { StyleSheet, View, Text, Platform, Alert } from 'react-native'
@@ -20,7 +21,8 @@ import earlierMessages from './example-expo/data/earlierMessages'
 import { NavBar } from './components/navbar'
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
+  container: { flex: 1, backgroundColor: '#f5f5f5', },
+  content: { backgroundColor: "#ffffff", flex: 1, }
 })
 
 const filterBotMessages = message =>
@@ -238,45 +240,47 @@ export default class App extends Component {
       return <AppLoading />
     }
     return (
-      <View
+      <SafeAreaView
         style={styles.container}
         accessibilityLabel='main'
         testID='main'
       >
         <NavBar />
-        <GiftedChat
-          messages={this.state.messages}
-          onSend={this.onSend}
-          loadEarlier={this.state.loadEarlier}
-          onLoadEarlier={this.onLoadEarlier}
-          isLoadingEarlier={this.state.isLoadingEarlier}
-          parsePatterns={this.parsePatterns}
-          user={user}
-          scrollToBottom
-          onLongPressAvatar={user => alert(JSON.stringify(user))}
-          onPressAvatar={() => alert('short press')}
-          onPress={() => {
-            Alert.alert('Bubble pressed')
-          }}
-          onQuickReply={this.onQuickReply}
-          keyboardShouldPersistTaps='never'
-          renderAccessory={Platform.OS === 'web' ? null : this.renderAccessory}
-          renderActions={this.renderCustomActions}
-          renderBubble={this.renderBubble}
-          renderSystemMessage={this.renderSystemMessage}
-          renderCustomView={this.renderCustomView}
-          renderSend={this.renderSend}
-          quickReplyStyle={{ borderRadius: 2 }}
-          quickReplyTextStyle={{
-            fontWeight: '200',
-          }}
-          renderQuickReplySend={this.renderQuickReplySend}
-          inverted={Platform.OS !== 'web'}
-          timeTextStyle={{ left: { color: 'red' }, right: { color: 'yellow' } }}
-          isTyping={this.state.isTyping}
-          infiniteScroll
-        />
-      </View>
+        <View style={styles.content}>
+          <GiftedChat
+            messages={this.state.messages}
+            onSend={this.onSend}
+            loadEarlier={this.state.loadEarlier}
+            onLoadEarlier={this.onLoadEarlier}
+            isLoadingEarlier={this.state.isLoadingEarlier}
+            parsePatterns={this.parsePatterns}
+            user={user}
+            scrollToBottom
+            onLongPressAvatar={user => alert(JSON.stringify(user))}
+            onPressAvatar={() => alert('short press')}
+            onPress={() => {
+              Alert.alert('Bubble pressed')
+            }}
+            onQuickReply={this.onQuickReply}
+            keyboardShouldPersistTaps='never'
+            renderAccessory={Platform.OS === 'web' ? null : this.renderAccessory}
+            renderActions={this.renderCustomActions}
+            renderBubble={this.renderBubble}
+            renderSystemMessage={this.renderSystemMessage}
+            renderCustomView={this.renderCustomView}
+            renderSend={this.renderSend}
+            quickReplyStyle={{ borderRadius: 2 }}
+            quickReplyTextStyle={{
+              fontWeight: '200',
+            }}
+            renderQuickReplySend={this.renderQuickReplySend}
+            inverted={Platform.OS !== 'web'}
+            timeTextStyle={{ left: { color: 'red' }, right: { color: 'yellow' } }}
+            isTyping={this.state.isTyping}
+            infiniteScroll
+          />
+        </View>
+      </SafeAreaView>
     )
   }
 }

--- a/example/components/navbar.tsx
+++ b/example/components/navbar.tsx
@@ -1,19 +1,17 @@
 import React from 'react'
-import { Text, Platform } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { View, Text, Platform } from 'react-native'
 
 export function NavBar() {
   if (Platform.OS === 'web') {
     return null
   }
   return (
-    <SafeAreaView
+    <View
       style={{
-        backgroundColor: '#f5f5f5',
         alignItems: 'center',
       }}
     >
       <Text>💬 Gifted Chat{'\n'}</Text>
-    </SafeAreaView>
+    </View>
   )
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "react-native-iphone-x-helper": "1.3.1",
     "react-native-lightbox-v2": "0.9.0",
     "react-native-parsed-text": "0.0.22",
-    "react-native-safe-area-context": "4.4.1",
     "react-native-typing-animation": "0.1.7",
     "use-memo-one": "1.1.2",
     "uuid": "3.4.0"
@@ -86,7 +85,6 @@
     "react-native-communications": "*",
     "react-native-lightbox": "*",
     "react-native-parsed-text": "*",
-    "react-native-safe-area-context": "*",
     "react-native-typing-animation": "*"
   },
   "husky": {

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -17,7 +17,6 @@ import {
   ActionSheetOptions,
 } from '@expo/react-native-action-sheet'
 import uuid from 'uuid'
-import { SafeAreaView } from 'react-native-safe-area-context'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 
@@ -72,8 +71,6 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   text?: string
   /* Controls whether or not the message bubbles appear at the top of the chat */
   alignTop?: boolean
-  /* Determine whether is wrapped in a SafeAreaView */
-  wrapInSafeArea?: boolean
   /* enables the scrollToBottom Component */
   scrollToBottom?: boolean
   /* Scroll to bottom wrapper style */
@@ -306,7 +303,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     extraData: null,
     minComposerHeight: MIN_COMPOSER_HEIGHT,
     maxComposerHeight: MAX_COMPOSER_HEIGHT,
-    wrapInSafeArea: true,
   }
 
   static propTypes = {
@@ -371,7 +367,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     minComposerHeight: PropTypes.number,
     maxComposerHeight: PropTypes.number,
     alignTop: PropTypes.bool,
-    wrapInSafeArea: PropTypes.bool,
   }
 
   static append<TMessage extends IMessage>(
@@ -594,10 +589,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     )
   }
 
-  safeAreaSupport = (bottomOffset?: number) => {
-    return bottomOffset != null ? bottomOffset : 1
-  }
-
   /**
    * Store text input focus status when keyboard hide to retrieve
    * it after wards if needed.
@@ -635,7 +626,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       this.setKeyboardHeight(
         e.endCoordinates ? e.endCoordinates.height : e.end.height,
       )
-      this.setBottomOffset(this.safeAreaSupport(this.props.bottomOffset))
       const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
       this.setState({
         messagesContainerHeight: newMessagesContainerHeight,
@@ -878,8 +868,6 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
 
   render() {
     if (this.state.isInitialized === true) {
-      const { wrapInSafeArea } = this.props
-      const Wrapper = wrapInSafeArea ? SafeAreaView : View
       const actionSheet =
         this.props.actionSheet ||
         (() => this._actionSheetRef.current?.getContext()!)
@@ -891,14 +879,14 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
             getLocale,
           }}
         >
-          <Wrapper testID={TEST_ID.WRAPPER} style={styles.safeArea}>
+          <View testID={TEST_ID.WRAPPER} style={styles.wrapper}>
             <ActionSheetProvider ref={this._actionSheetRef}>
               <View style={styles.container} onLayout={this.onMainViewLayout}>
                 {this.renderMessages()}
                 {this.renderInputToolbar()}
               </View>
             </ActionSheetProvider>
-          </Wrapper>
+          </View>
         </GiftedChatContext.Provider>
       )
     }
@@ -918,7 +906,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  safeArea: {
+  wrapper: {
     flex: 1,
   },
 })

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,2 @@
-import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock'
-
 // mocks
 jest.mock('@expo/react-native-action-sheet', () => 'ActionSheet')
-jest.mock('react-native-safe-area-context', () => mockSafeAreaContext)


### PR DESCRIPTION
This is a proposal PR to remove the need to use `react-native-safe-area-context` as a dependency. From experience, it seems most developers handle `<SafeAreaView>`'s on their own terms. 

Furthermore, based on what I see, the GiftedChat library is currently using SafeAreaView so that the Example app can have spacing, but beyond that it doesn't seem to offer much more benefit or is a necessary thing.

In addition, a good chunk of issues are caused by GiftedChat trying to apply SafeAreaView without this being documented. Though I now see a PR by someone else for that https://github.com/FaridSafi/react-native-gifted-chat/pull/2336

Because the SafeAreaView dep is not being updated it often causes problems such as:

- https://github.com/FaridSafi/react-native-gifted-chat/issues/2349
- https://github.com/FaridSafi/react-native-gifted-chat/issues/2319
- https://github.com/FaridSafi/react-native-gifted-chat/issues/2352
- https://github.com/FaridSafi/react-native-gifted-chat/issues/2267
- https://github.com/FaridSafi/react-native-gifted-chat/issues/2251

And these PR's attempt to update the version 

- https://github.com/FaridSafi/react-native-gifted-chat/pull/2278
- https://github.com/FaridSafi/react-native-gifted-chat/pull/2286
- https://github.com/FaridSafi/react-native-gifted-chat/pull/2348

However, I still think it's better to just remove SafeAreaView from `<GiftedChat />` altogether. I feel like it will save a lot of headaches for the maintainers from having to always be updating `react-native-safe-area-context` when it practically adds no useful functionality to the library. I'm open to feedback. :)