### PR TITLE
Fixes crash with: Tried to get frame for out of range index -1 [scrollToBottom (scrollToEnd of list with inverted option) only if messages available/loaded]

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -436,6 +436,9 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
   const scrollToBottom = (animated = true) => {
     if (messageContainerRef?.current) {
       if (!inverted) {
+        if (!messages?.length) {
+          return;
+        }
         messageContainerRef.current.scrollToEnd({ animated })
       } else {
         messageContainerRef.current.scrollToOffset({


### PR DESCRIPTION
Without this fix we end-up having 
`Tried to get frame for out of range index -1` error thrown from the underlying FlatList

This is currently causing a lot of crashes on Production for us. The crashes happen when we try to navigate to the chat window directly from push notifications