### PR TITLE
(fix) Apply bottomOffset when keyboard is shown

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -626,6 +626,7 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
       this.setKeyboardHeight(
         e.endCoordinates ? e.endCoordinates.height : e.end.height,
       )
+      this.setBottomOffset(this.props.bottomOffset != null ? this.props.bottomOffset : 1)
       const newMessagesContainerHeight = this.getMessagesContainerHeightWithKeyboard()
       this.setState({
         messagesContainerHeight: newMessagesContainerHeight,


### PR DESCRIPTION
Applying the `bottomOffset` prop was inadvertently removed in the PR to remove the react-safe-area-context dependency [#2353](https://github.com/FaridSafi/react-native-gifted-chat/pull/2353)  The `bottomOffset` props is often used when using React Navigation tabs for iOS to remove the gap created between the input/chat and keyboard. This PR restores the previous functionality of the `bottomOffset` prop.

Prior to this PR the `bottomOffset` prop was always applied when the `onKeyboardWillShow` event was fired. This happened regardless if gifted chat was wrapped in a safe area or not.

https://github.com/FaridSafi/react-native-gifted-chat/blob/75e75f0a7916379e7b4a3f3c25e8360f1e856d17/src/GiftedChat.tsx#L638

https://github.com/FaridSafi/react-native-gifted-chat/blob/75e75f0a7916379e7b4a3f3c25e8360f1e856d17/src/GiftedChat.tsx#L597-L599

I've reviewed this with the PR author [amerikan](https://github.com/amerikan) (Thanks again for getting rid of this dependency!), and we both agree that this PR would resolve & restore the previous behavior.
