### PR TITLE
 #2367 Extend Bubble and Message base classes in the Slack examples

### DIFF
--- a/example/example-slack-message/src/SlackBubble.js
+++ b/example/example-slack-message/src/SlackBubble.js
@@ -17,11 +17,12 @@ import {
   MessageImage,
   Time,
   utils,
+  Bubble
 } from 'react-native-gifted-chat'
 
 const { isSameUser, isSameDay } = utils
 
-export default class Bubble extends React.Component {
+export default class SlackBubble extends Bubble {
   constructor(props) {
     super(props)
     this.onLongPress = this.onLongPress.bind(this)

--- a/example/example-slack-message/src/SlackBubble.js
+++ b/example/example-slack-message/src/SlackBubble.js
@@ -25,10 +25,10 @@ const { isSameUser, isSameDay } = utils
 export default class SlackBubble extends Bubble {
   constructor(props) {
     super(props)
-    this.onLongPress = this.onLongPress.bind(this)
+    }
   }
 
-  onLongPress() {
+  onLongPress = () => {
     if (this.props.onLongPress) {
       this.props.onLongPress(this.context, this.props.currentMessage)
     } else {
@@ -50,7 +50,6 @@ export default class SlackBubble extends Bubble {
         )
       }
     }
-  }
 
   renderMessageText() {
     if (this.props.currentMessage.text) {

--- a/example/example-slack-message/src/SlackMessage.js
+++ b/example/example-slack-message/src/SlackMessage.js
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { View, ViewPropTypes, StyleSheet } from 'react-native'
 
-import { Avatar, Day, utils } from 'react-native-gifted-chat'
-import Bubble from './SlackBubble'
+import { Avatar, Day, utils, Message } from 'react-native-gifted-chat'
+import SlackBubble from './SlackBubble'
 
 const { isSameUser, isSameDay } = utils
 
-export default class Message extends React.Component {
+export default class SlackMessage extends Message {
   getInnerComponentProps() {
     const { containerStyle, ...props } = this.props
     return {
@@ -36,7 +36,7 @@ export default class Message extends React.Component {
     if (this.props.renderBubble) {
       return this.props.renderBubble(bubbleProps)
     }
-    return <Bubble {...bubbleProps} />
+    return <SlackBubble {...bubbleProps} />
   }
 
   renderAvatar() {


### PR DESCRIPTION
This fixes issue [ #2367](https://github.com/FaridSafi/react-native-gifted-chat/issues/2367) by extending the base Bubble and Message classes within the slack example. This allows the SlackBubble class for example to access the GiftedChatContext which is necessary for the long press action.

Arguably there should be more code cleanup within the classes to remove render functions that are duplicative but to keep it simple this will work.