### PR TITLE
Prevent the context from changing which forces unnecessary rerenders

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useRef, useEffect, useState } from 'react'
+import React, { useRef, useEffect, useState, useMemo } from 'react'
 import {
   Animated,
   Platform,
@@ -751,14 +751,13 @@ function GiftedChat(props: GiftedChatProps) {
   }
 
   if (state.isInitialized === true) {
-    const _actionSheet =
-      actionSheet || (() => _actionSheetRef.current?.getContext()!)
+    const contextValues = useMemo(() => ({
+      actionSheet: actionSheet || (() => _actionSheetRef.current?.getContext()!),
+      getLocale: getLocale,
+    }), [actionSheet, locale])
     return (
       <GiftedChatContext.Provider
-        value={{
-          actionSheet: _actionSheet,
-          getLocale: getLocale,
-        }}
+        value={contextValues}
       >
         <View testID={TEST_ID.WRAPPER} style={styles.wrapper}>
           <ActionSheetProvider ref={_actionSheetRef}>


### PR DESCRIPTION
Fixes #2370 by saving the context as a state object so the object doesn't change. Currently whenever the GiftedChat component re-renders it causes the context to change as the context is given a new value. this causes all the components that rely on the context to update, which is a lot of them.