### PR TITLE
Update use-memo-one package

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-native-lightbox-v2": "0.9.0",
     "react-native-parsed-text": "0.0.22",
     "react-native-typing-animation": "0.1.7",
-    "use-memo-one": "1.1.2",
+    "use-memo-one": "1.1.3",
     "uuid": "3.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Changes
- Allowing react@18 as a react peerDependency.

Issue
- Showing warning in react-native-gifted-chat package install time.
![Screenshot 2023-06-07 at 8 28 58 PM](https://github.com/FaridSafi/react-native-gifted-chat/assets/36645339/c245bb76-fa3a-4eee-b9b7-20570b31db2e)


Reference 
https://github.com/alexreardon/use-memo-one/releases/tag/v1.1.3