### PR TITLE
chore: fix to use strict equality

### DIFF
--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -55,7 +55,10 @@ export function Day<TMessage extends IMessage = IMessage>({
 }: DayProps<TMessage>) {
   const { getLocale } = useChatContext()
 
-  if (currentMessage == null || isSameDay(currentMessage, previousMessage)) {
+  if (
+    currentMessage === undefined ||
+    isSameDay(currentMessage, previousMessage)
+  ) {
     return null
   }
 

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -387,7 +387,7 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
         ? e.endCoordinates.height
         : e.end.height
 
-      bottomOffsetRef.current = bottomOffset != null ? bottomOffset : 1
+      bottomOffsetRef.current = bottomOffset !== null ? bottomOffset : 1
 
       const newMessagesContainerHeight = getMessagesContainerHeightWithKeyboard()
 

--- a/src/MessageImage.tsx
+++ b/src/MessageImage.tsx
@@ -44,7 +44,7 @@ export function MessageImage<TMessage extends IMessage = IMessage>({
   imageStyle,
   currentMessage,
 }: MessageImageProps<TMessage>) {
-  if (currentMessage == null) {
+  if (currentMessage === undefined) {
     return null
   }
 

--- a/src/SystemMessage.tsx
+++ b/src/SystemMessage.tsx
@@ -41,7 +41,7 @@ export function SystemMessage<TMessage extends IMessage = IMessage>({
   wrapperStyle,
   textStyle,
 }: SystemMessageProps<TMessage>) {
-  if (currentMessage == null || currentMessage.system == false) {
+  if (currentMessage === undefined || currentMessage.system === false) {
     return null
   }
 

--- a/src/Time.tsx
+++ b/src/Time.tsx
@@ -61,7 +61,7 @@ export function Time<TMessage extends IMessage = IMessage>({
   timeTextStyle,
 }: TimeProps<TMessage>) {
   const { getLocale } = useChatContext()
-  if (currentMessage == null) {
+  if (currentMessage === undefined) {
     return null
   }
 


### PR DESCRIPTION
Thank you for everything.

To prevent unexpected behavior due to implicit type conversion, I have made use of the strict equality operator.

This is my first time contributing to this repository, so please let me know if there are any oddities.