### PR TITLE
fix: use messages from props instead of state

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/react": "~16.9.35",
     "@types/react-native": "~0.63.2",
     "@types/react-test-renderer": "16.9.2",
-    "@types/uuid": "3.4.9",
+    "@types/uuid": "9.0.2",
     "@typescript-eslint/eslint-plugin": "5.18.0",
     "@typescript-eslint/parser": "5.18.0",
     "babel-jest": "27.5.1",
@@ -75,7 +75,7 @@
     "react-native-parsed-text": "0.0.22",
     "react-native-typing-animation": "0.1.7",
     "use-memo-one": "1.1.3",
-    "uuid": "3.4.0"
+    "uuid": "9.0.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -219,13 +219,12 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   ): boolean
 }
 
-export interface GiftedChatState<TMessage extends IMessage = IMessage> {
+export interface GiftedChatState {
   isInitialized: boolean
   composerHeight?: number
   messagesContainerHeight?: number | Animated.Value
   typingDisabled: boolean
   text?: string
-  messages?: TMessage[]
 }
 
 function GiftedChat<TMessage extends IMessage = IMessage>(
@@ -279,7 +278,6 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
     messagesContainerHeight: undefined,
     typingDisabled: false,
     text: undefined,
-    messages: undefined,
   })
 
   useEffect(() => {
@@ -287,7 +285,6 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
 
     setState({
       ...state,
-      messages,
       // Text prop takes precedence over state.
       ...(text !== undefined && text !== state.text && { text: text }),
     })
@@ -473,7 +470,7 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
             onKeyboardDidShow: onKeyboardDidShow,
             onKeyboardDidHide: onKeyboardDidHide,
           }}
-          messages={state.messages}
+          messages={messages}
           forwardRef={messageContainerRef}
           isTyping={isTyping}
         />

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -21,7 +21,7 @@ import {
   ViewStyle,
 } from 'react-native'
 import { LightboxProps } from 'react-native-lightbox-v2'
-import uuid from 'uuid'
+import { v4 as uuidV4 } from 'uuid'
 import { Actions, ActionsProps } from './Actions'
 import { Avatar, AvatarProps } from './Avatar'
 import Bubble from './Bubble'
@@ -236,7 +236,7 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
     text = undefined,
     initialText = '',
     isTyping,
-    messageIdGenerator = () => uuid.v4(),
+    messageIdGenerator = () => uuidV4(),
     user = {},
     onSend = () => {},
     locale = 'en',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,10 +2450,10 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/uuid@3.4.9":
-  version "3.4.9"
-  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz"
-  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
+"@types/uuid@9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -7822,7 +7822,12 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@3.4.0, uuid@^3.3.2:
+uuid@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
it's unclear why the messages were attached to state, but there was some effect resetting them, so the chat view was empty, even if it had messages.

the message container now uses the messages from props.