### PR TITLE
add getItemLayout to GiftedChatProps

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -134,6 +134,10 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* infinite scroll up when reach the top of messages container, automatically call onLoadEarlier function if exist */
   infiniteScroll?: boolean
   timeTextStyle?: LeftRightStyle<TextStyle>
+  getItemLayout?: (
+    data: Array<any> | null | undefined,
+    index: number,
+  ) => { length: number; offset: number; index: number }
   /* Custom action sheet */
   actionSheet?(): {
     showActionSheetWithOptions: (
@@ -452,7 +456,11 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
   }
 
   const renderMessages = () => {
-    const { messagesContainerStyle, ...messagesContainerProps } = props
+    const {
+      messagesContainerStyle,
+      getItemLayout,
+      ...messagesContainerProps
+    } = props
 
     const fragment = (
       <View
@@ -475,6 +483,7 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
           }}
           messages={state.messages}
           forwardRef={messageContainerRef}
+          getItemLayout={getItemLayout}
           isTyping={isTyping}
         />
         {_renderChatFooter()}
@@ -808,21 +817,21 @@ const styles = StyleSheet.create({
 
 export * from './Models'
 export {
-  GiftedChat,
   Actions,
   Avatar,
   Bubble,
-  SystemMessage,
-  MessageImage,
-  MessageText,
   Composer,
   Day,
+  GiftedAvatar,
+  GiftedChat,
   InputToolbar,
   LoadEarlier,
   Message,
   MessageContainer,
+  MessageImage,
+  MessageText,
   Send,
+  SystemMessage,
   Time,
-  GiftedAvatar,
   utils,
 }

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -3,27 +3,27 @@ import React, { RefObject } from 'react'
 
 import {
   FlatList,
-  View,
-  StyleSheet,
-  TouchableOpacity,
-  Text,
-  ListViewProps,
   ListRenderItemInfo,
-  NativeSyntheticEvent,
+  ListViewProps,
   NativeScrollEvent,
-  StyleProp,
-  ViewStyle,
+  NativeSyntheticEvent,
   Platform,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
 } from 'react-native'
 
+import Color from './Color'
 import { LoadEarlier, LoadEarlierProps } from './LoadEarlier'
 import Message from './Message'
-import Color from './Color'
-import { User, IMessage, Reply } from './Models'
+import { IMessage, Reply, User } from './Models'
 import TypingIndicator from './TypingIndicator'
 
-import { StylePropType } from './utils'
 import { warning } from './logging'
+import { StylePropType } from './utils'
 
 const styles = StyleSheet.create({
   container: {
@@ -80,6 +80,10 @@ export interface MessageContainerProps<TMessage extends IMessage> {
   extraData?: any
   scrollToBottomOffset?: number
   forwardRef?: RefObject<FlatList<IMessage>>
+  getItemLayout?: (
+    data: Array<any> | null | undefined,
+    index: number,
+  ) => { length: number; offset: number; index: number }
   renderChatEmpty?(): React.ReactNode
   renderFooter?(props: MessageContainerProps<TMessage>): React.ReactNode
   renderMessage?(props: Message['props']): React.ReactNode
@@ -349,6 +353,7 @@ export default class MessageContainer<
           automaticallyAdjustContentInsets={false}
           inverted={inverted}
           data={this.props.messages}
+          getItemLayout={this.props.getItemLayout}
           style={styles.listStyle}
           contentContainerStyle={styles.contentContainerStyle}
           renderItem={this.renderRow}


### PR DESCRIPTION
I was trying to implement a functionality that allows the user to click on a reply message that is rendered using renderCustomView and lets them jump to the original post of the reply message.
I decided to use the `messageContainerRef.current?.scrollToIndex` function, but because `getItemLayout` isn't provided to the FlatList component in gifted chat, it is kinda buggy and raises an error sometimes. I looked for a way to define `getItemLayout` in my application, but it doesn't seem like a way to pass it down through props. Does anyone know of a way around this?  I'll close this PR if there is a way to provide getItemLayout to FlatList. I'll create an issue as well.