### PR TITLE
fix: Remove potential race conditions from setState changes

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -289,7 +289,7 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
       ...prevState,
       messages,
       // Text prop takes precedence over state.
-      ...(text !== undefined && text !== state.text && { text: text }),
+      ...(text !== undefined && text !== prevState.text && { text: text }),
     }))
 
     if (inverted === false && messages?.length) {

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -285,12 +285,12 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
   useEffect(() => {
     isMountedRef.current = true
 
-    setState({
-      ...state,
+    setState((prevState:GiftedChatState) => ({
+      ...prevState,
       messages,
       // Text prop takes precedence over state.
       ...(text !== undefined && text !== state.text && { text: text }),
-    })
+    }))
 
     if (inverted === false && messages?.length) {
       setTimeout(() => scrollToBottom(false), 200)
@@ -391,11 +391,11 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
 
       const newMessagesContainerHeight = getMessagesContainerHeightWithKeyboard()
 
-      setState({
-        ...state,
+      setState((prevState:GiftedChatState) => ({
+        ...prevState,
         typingDisabled: true,
         messagesContainerHeight: newMessagesContainerHeight,
-      })
+      }))
     }
   }
 
@@ -408,11 +408,11 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
 
       const newMessagesContainerHeight = getBasicMessagesContainerHeight()
 
-      setState({
-        ...state,
+      setState((prevState:GiftedChatState) => ({
+        ...prevState,
         typingDisabled: true,
         messagesContainerHeight: newMessagesContainerHeight,
-      })
+      }))
     }
   }
 
@@ -421,10 +421,10 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
       onKeyboardWillShow(e)
     }
 
-    setState({
-      ...state,
+    setState((prevState:GiftedChatState) => ({
+      ...prevState,
       typingDisabled: false,
-    })
+    }))
   }
 
   const onKeyboardDidHide = (e: any) => {
@@ -432,10 +432,10 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
       onKeyboardWillHide(e)
     }
 
-    setState({
-      ...state,
+    setState((prevState:GiftedChatState) => ({
+      ...prevState,
       typingDisabled: false,
-    })
+    }))
   }
 
   const scrollToBottom = (animated = true) => {
@@ -506,10 +506,10 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
     })
 
     if (shouldResetInputToolbar === true) {
-      setState({
-        ...state,
+      setState((prevState:GiftedChatState) => ({
+        ...prevState,
         typingDisabled: true,
-      })
+      }))
 
       resetInputToolbar()
     }
@@ -541,12 +541,12 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
       minComposerHeight,
     )
 
-    setState({
-      ...state,
+    setState((prevState:GiftedChatState) => ({
+      ...prevState,
       text: getTextFromProp(''),
       composerHeight: minComposerHeight,
       messagesContainerHeight: newMessagesContainerHeight,
-    })
+    }))
   }
 
   const onInputSizeChanged = (size: { height: number }) => {
@@ -559,11 +559,11 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
       newComposerHeight,
     )
 
-    setState({
-      ...state,
+    setState((prevState:GiftedChatState) => ({
+      ...prevState,
       composerHeight: newComposerHeight,
       messagesContainerHeight: newMessagesContainerHeight,
-    })
+    }))
   }
 
   const _onInputTextChanged = (_text: string) => {
@@ -577,7 +577,7 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
 
     // Only set state if it's not being overridden by a prop.
     if (text === undefined) {
-      setState({ ...state, text: _text })
+      setState((prevState:GiftedChatState) => ({ ...prevState, text: _text }))
     }
   }
 
@@ -602,13 +602,13 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
       minComposerHeight,
     )
 
-    setState({
-      ...state,
+    setState((prevState:GiftedChatState) =>({
+      ...prevState,
       isInitialized: true,
       text: getTextFromProp(initialText),
       composerHeight: minComposerHeight,
       messagesContainerHeight: newMessagesContainerHeight,
-    })
+    }))
   }
 
   const onMainViewLayout = (e: LayoutChangeEvent) => {
@@ -621,13 +621,13 @@ function GiftedChat<TMessage extends IMessage = IMessage>(
     ) {
       maxHeightRef.current = layout.height
 
-      setState({
-        ...state,
+      setState((prevState:GiftedChatState) =>({
+        ...prevState,
         messagesContainerHeight:
           keyboardHeightRef.current > 0
             ? getMessagesContainerHeightWithKeyboard()
             : getBasicMessagesContainerHeight(),
-      })
+      }))
     }
 
     if (isFirstLayoutRef.current === true) {


### PR DESCRIPTION
Hi, so i was using react-native-gifted-chat and had a race condition because my stream of messages happened at the same time as the "onLayout" event which made the isInitialized variable remain false as it was overwritten by a stale state value when the messages array was updated at the same time as onLayout.  This happens because setState is being called using a the local state value.  

I updated all the setState functions to use the state value passed by the function which is always up to date so you don't have any possibility of writing to state with a stale value. 