### PR TITLE
fix(typing): use generic TMessage on GiftedChat props

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -54,7 +54,7 @@ dayjs.extend(localizedFormat)
 
 export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   /* Message container ref */
-  messageContainerRef?: React.RefObject<FlatList<IMessage>>
+  messageContainerRef?: React.RefObject<FlatList<TMessage>>
   /* text input ref */
   textInputRef?: React.RefObject<TextInput>
   /* Messages to display */
@@ -229,7 +229,7 @@ export interface GiftedChatState<TMessage extends IMessage = IMessage> {
 }
 
 function GiftedChat<TMessage extends IMessage = IMessage>(
-  props: GiftedChatProps,
+  props: GiftedChatProps<TMessage>,
 ) {
   const {
     messages = [],


### PR DESCRIPTION
When using a custom type for message object, GiftedChat component needs to properly use type parameters when defining props.

Following deb4c45b64c36b076760fe7e8ee2caf66333b8c5, the type parameter from the generic `TMessage` when declaring the class component props got lost in translation and thus broke previously valid use cases with custom message object types.

Despite some efforts in 39720e32dc6180922e84d69b0e81f797ae105cf2, the type parameter still wasn't used and it did not fix this use-case.

This PR adds back the generic type parameter to GiftedChat's props.

### Minimum repro

```tsx
import { View, Text } from 'react-native'
import {
  GiftedChat,
  IMessage,
} from 'react-native-gifted-chat'

type ChatMessage = IMessage & {
  user: IMessage['user'] & {
    isAdmin: boolean,
  },
}

type Props = {
  messages: ChatMessage[],
}

export const CustomChat = (props: Props) => (
  <GiftedChat
    messages={props.messages}
    renderMessage={(messageProps) => (
      <View>
        {messageProps.currentMessage?.user.isAdmin && ( // Property 'isAdmin' does not exist on type 'User'.ts(2339)
          <Text>Admin</Text>
        )}
        <Text>{messageProps.currentMessage?.text}</Text>
      </View>
    )}
  />
)
```

### Patch

For those who want to quickly fix the typing issue locally, you may use the following patch.
<details>
<summary>Patch for node_modules</summary>

```patch
diff --git a/node_modules/react-native-gifted-chat/lib/GiftedChat.d.ts b/node_modules/react-native-gifted-chat/lib/GiftedChat.d.ts
index 0444a70..77f695e 100644
--- a/node_modules/react-native-gifted-chat/lib/GiftedChat.d.ts
+++ b/node_modules/react-native-gifted-chat/lib/GiftedChat.d.ts
@@ -117,7 +117,7 @@ export interface GiftedChatState<TMessage extends IMessage = IMessage> {
     text?: string;
     messages?: TMessage[];
 }
-declare function GiftedChat<TMessage extends IMessage = IMessage>(props: GiftedChatProps): JSX.Element;
+declare function GiftedChat<TMessage extends IMessage = IMessage>(props: GiftedChatProps<TMessage>): JSX.Element;
 declare namespace GiftedChat {
     var propTypes: {
         messages: PropTypes.Requireable<(object | null | undefined)[]>;

```
</details>