### PR TITLE
Add `bottomOffset` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ interface QuickReplies {
 - **`renderSend`** _(Function)_ - Custom send button; you can pass children to the original `Send` component quite easily, for example, to use a custom icon ([example](https://github.com/FaridSafi/react-native-gifted-chat/pull/487))
 - **`renderAccessory`** _(Function)_ - Custom second line of actions below the message composer
 - **`onPressActionButton`** _(Function)_ - Callback when the Action button is pressed (if set, the default `actionSheet` will not be used)
+- **`bottomOffset`** _(Integer)_ - Distance of the chat from the bottom of the screen (e.g. useful if you display a tab bar)
 - **`minInputToolbarHeight`** _(Integer)_ - Minimum height of the input toolbar; default is `44`
 - **`listViewProps`** _(Object)_ - Extra props to be passed to the messages [`<ListView>`](https://facebook.github.io/react-native/docs/listview.html); some props can't be overridden, see the code in `MessageContainer.render()` for details
 - **`textInputProps`** _(Object)_ - Extra props to be passed to the [`<TextInput>`](https://facebook.github.io/react-native/docs/textinput.html)

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -113,6 +113,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   imageProps?: Message<TMessage>['props']
   /* Extra props to be passed to the MessageImage's Lightbox */
   lightboxProps?: LightboxProps
+  /* Distance of the chat from the bottom of the screen (e.g. useful if you display a tab bar); default is 0 */
+  bottomOffset?: number
   /* Minimum height of the input toolbar; default is 44 */
   minInputToolbarHeight?: number
   /* Extra props to be passed to the messages <ListView>; some props can't be overridden, see the code in MessageContainer.render() for details */
@@ -244,6 +246,7 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
     textInputProps,
     renderChatFooter = null,
     renderInputToolbar = null,
+    bottomOffset = 0,
     keyboardShouldPersistTaps = Platform.select({
       ios: 'never',
       android: 'always',
@@ -556,9 +559,10 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
         if (isKeyboardMovingUp !== trackingKeyboardMovement.value) {
           trackingKeyboardMovement.value = isKeyboardMovingUp
           keyboardOffsetBottom.value = withTiming(
-            isKeyboardMovingUp ? insets.bottom : 0,
+            isKeyboardMovingUp ? insets.bottom + bottomOffset : 0,
             {
-              duration: 400,
+              // If `bottomOffset` exists, we change the duration to a smaller value to fix the delay in the keyboard animation speed
+              duration: bottomOffset ? 150 : 400,
             }
           )
 


### PR DESCRIPTION
`bottomOffset` option was removed when merging [this PR](https://github.com/FaridSafi/react-native-gifted-chat/pull/2493/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L388).

I tried to get it back