### PR TITLE
Show typing indicator on web platform

### DIFF
--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -148,9 +148,6 @@ export default class MessageContainer<
   }
 
   renderTypingIndicator = () => {
-    if (Platform.OS === 'web')
-      return null
-
     return <TypingIndicator isTyping={this.props.isTyping || false} />
   }
 


### PR DESCRIPTION
I don't understand why this condition is existing.
There is no way to show the typing indicator on the web platform if this condition is here.

I suggest to remove this condition to allow developer to show this indicator