### PR TITLE
Fix initial keyboard animation if `prevValue` is `0`

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -559,7 +559,7 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
   useAnimatedReaction(
     () => keyboard.height.value,
     (value, prevValue) => {
-      if (prevValue && value !== prevValue) {
+      if (prevValue !== null && value !== prevValue) {
         const isKeyboardMovingUp = value > prevValue
         if (isKeyboardMovingUp !== trackingKeyboardMovement.value) {
           trackingKeyboardMovement.value = isKeyboardMovingUp


### PR DESCRIPTION
After adding support for `bottomOffset` I found some case on iOS:

When we first open the keyboard on iOS we skip the animation logic because `prevValue` is `0`:
```
 value 260
 prevValue 0
 // (prevValue && value !== prevValue) is false
```

We don't see this issue on Android, as the keyboard gets a bunch of values ​​when first opened:
```
 value 0
 prevValue 0
 // (prevValue && value !== prevValue) is false
 value 18
 prevValue 0
 // (prevValue && value !== prevValue) is false
 value 50
 prevValue 18
 // (prevValue && value !== prevValue) is true
```
(all of these triggers above are triggered on first press)

`prevValue` can be `null` or a number, and I couldn't understand why we check `prevValue` instead of `prevValue !== null`, so I changed this condition.