### PR TITLE
fix onPressActionButton not being called

### DIFF
--- a/src/InputToolbar.tsx
+++ b/src/InputToolbar.tsx
@@ -42,6 +42,7 @@ export function InputToolbar<TMessage extends IMessage = IMessage> (
 
   const actionsFragment = useMemo(() => {
     const props = {
+      onPressActionButton,
       options,
       optionTintColor,
       icon,


### PR DESCRIPTION
This add the `onPressActionButton` as props to `Actions` elements

Fix https://github.com/FaridSafi/react-native-gifted-chat/issues/2560