### PR TITLE
fixed: focus handling when opening keyboard

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -329,7 +329,7 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
   const handleTextInputFocusWhenKeyboardShow = useCallback(() => {
     if (
       textInputRef.current &&
-      isTextInputWasFocused &&
+      isTextInputWasFocused.current &&
       !textInputRef.current.isFocused()
     )
       textInputRef.current.focus()


### PR DESCRIPTION
This PR resolves an issue with focus handling when opening the keyboard. I discovered that when an input field inside a modal on the chat page receives focus, the focus was incorrectly being intercepted by the chat input. The check for `isTextInputWasFocused: MutableRefObject<boolean>` was incorrect, so it has been replaced with a value check.

All tests have passed successfully. However, given my limited experience with this library, I would appreciate it if someone familiar with the project could review this change to ensure it doesn't unintentionally alter any critical behavior.

Let me know if you want any changes to it