### PR TITLE
expose renderTypingIndicator and handleOnScroll which are already pas…

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -66,7 +66,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 dayjs.extend(localizedFormat)
 
-export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
+export interface GiftedChatProps<TMessage extends IMessage = IMessage> extends Partial<Omit<MessageContainer<TMessage>, 'scrollToBottom'>> {
   /* Message container ref */
   messageContainerRef?: React.RefObject<FlatList<IMessage>>
   /* text input ref */

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -162,16 +162,12 @@ export default class MessageContainer<
     return this.renderTypingIndicator()
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  renderLoadEarlier = (_props: LoadEarlierProps) => {
+  renderLoadEarlier = (props: LoadEarlierProps) => {
     if (this.props.loadEarlier === true) {
-      const loadEarlierProps = {
-        ...this.props,
-      }
       if (this.props.renderLoadEarlier)
-        return this.props.renderLoadEarlier(loadEarlierProps)
+        return this.props.renderLoadEarlier(props)
 
-      return <LoadEarlier {...loadEarlierProps} />
+      return <LoadEarlier {...props} />
     }
     return null
   }
@@ -267,7 +263,7 @@ export default class MessageContainer<
   }
 
   renderHeaderWrapper = () => (
-    <View style={styles.headerWrapper}>{this.renderLoadEarlier(this.props)}</View>
+    <View style={styles.headerWrapper}>{this.renderLoadEarlier({ ...this.props })}</View>
   )
 
   renderScrollBottomComponent () {

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -83,11 +83,13 @@ export interface MessageContainerProps<TMessage extends IMessage> {
   renderFooter?(props: MessageContainerProps<TMessage>): React.ReactNode
   renderMessage?(props: Message['props']): React.ReactElement
   renderLoadEarlier?(props: LoadEarlierProps): React.ReactNode
+  renderTypingIndicator?(): React.ReactNode
   scrollToBottomComponent?(): React.ReactNode
   onLoadEarlier?(): void
   onQuickReply?(replies: Reply[]): void
   infiniteScroll?: boolean
   isLoadingEarlier?: boolean
+  handleOnScroll?(event: NativeSyntheticEvent<NativeScrollEvent>): void
 }
 
 interface State {
@@ -148,6 +150,8 @@ export default class MessageContainer<
   }
 
   renderTypingIndicator = () => {
+    if (this.props.renderTypingIndicator)
+      return this.props.renderTypingIndicator()
     return <TypingIndicator isTyping={this.props.isTyping || false} />
   }
 
@@ -158,7 +162,7 @@ export default class MessageContainer<
     return this.renderTypingIndicator()
   }
 
-  renderLoadEarlier = () => {
+  renderLoadEarlier = (props: LoadEarlierProps) => {
     if (this.props.loadEarlier === true) {
       const loadEarlierProps = {
         ...this.props,
@@ -168,7 +172,7 @@ export default class MessageContainer<
 
       return <LoadEarlier {...loadEarlierProps} />
     }
-    return null
+    return this.props.renderLoadEarlier?.(props)
   }
 
   scrollTo (options: { animated?: boolean, offset: number }) {
@@ -185,6 +189,7 @@ export default class MessageContainer<
   }
 
   handleOnScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    this.props.handleOnScroll?.(event)
     const {
       nativeEvent: {
         contentOffset: { y: contentOffsetY },
@@ -261,7 +266,7 @@ export default class MessageContainer<
   }
 
   renderHeaderWrapper = () => (
-    <View style={styles.headerWrapper}>{this.renderLoadEarlier()}</View>
+    <View style={styles.headerWrapper}>{this.renderLoadEarlier(this.props)}</View>
   )
 
   renderScrollBottomComponent () {

--- a/src/MessageContainer.tsx
+++ b/src/MessageContainer.tsx
@@ -162,7 +162,8 @@ export default class MessageContainer<
     return this.renderTypingIndicator()
   }
 
-  renderLoadEarlier = (props: LoadEarlierProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  renderLoadEarlier = (_props: LoadEarlierProps) => {
     if (this.props.loadEarlier === true) {
       const loadEarlierProps = {
         ...this.props,
@@ -172,7 +173,7 @@ export default class MessageContainer<
 
       return <LoadEarlier {...loadEarlierProps} />
     }
-    return this.props.renderLoadEarlier?.(props)
+    return null
   }
 
   scrollTo (options: { animated?: boolean, offset: number }) {


### PR DESCRIPTION
address the need for [this patch](https://github.com/FaridSafi/react-native-gifted-chat/issues/2564)

These properties are already passed to the underlying `MessageContainer` component, so might as well expose them to the developer