### PR TITLE
Add `focusOnInputWhenKeyboardOpens` prop to disable focus on `<TextInput />` when opening the keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ interface QuickReplies {
 - **`renderAccessory`** _(Function)_ - Custom second line of actions below the message composer
 - **`onPressActionButton`** _(Function)_ - Callback when the Action button is pressed (if set, the default `actionSheet` will not be used)
 - **`bottomOffset`** _(Integer)_ - Distance of the chat from the bottom of the screen (e.g. useful if you display a tab bar)
+- **`focusOnInputWhenOpeningKeyboard`** _(Bool)_ - Focus on <TextInput> automatically when opening the keyboard; default `true`
 - **`minInputToolbarHeight`** _(Integer)_ - Minimum height of the input toolbar; default is `44`
 - **`listViewProps`** _(Object)_ - Extra props to be passed to the messages [`<ListView>`](https://facebook.github.io/react-native/docs/listview.html); some props can't be overridden, see the code in `MessageContainer.render()` for details
 - **`textInputProps`** _(Object)_ - Extra props to be passed to the [`<TextInput>`](https://facebook.github.io/react-native/docs/textinput.html)

--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -117,6 +117,8 @@ export interface GiftedChatProps<TMessage extends IMessage = IMessage> {
   lightboxProps?: LightboxProps
   /* Distance of the chat from the bottom of the screen (e.g. useful if you display a tab bar); default is 0 */
   bottomOffset?: number
+  /* Focus on <TextInput> automatically when opening the keyboard; default is true */
+  focusOnInputWhenOpeningKeyboard?: boolean
   /* Minimum height of the input toolbar; default is 44 */
   minInputToolbarHeight?: number
   /* Extra props to be passed to the messages <ListView>; some props can't be overridden, see the code in MessageContainer.render() for details */
@@ -251,6 +253,7 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
     renderChatFooter = null,
     renderInputToolbar = null,
     bottomOffset = 0,
+    focusOnInputWhenOpeningKeyboard = true,
     keyboardShouldPersistTaps = Platform.select({
       ios: 'never',
       android: 'always',
@@ -571,10 +574,11 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
             }
           )
 
-          if (isKeyboardMovingUp)
-            runOnJS(handleTextInputFocusWhenKeyboardShow)()
-          else
-            runOnJS(handleTextInputFocusWhenKeyboardHide)()
+          if (focusOnInputWhenOpeningKeyboard)
+            if (isKeyboardMovingUp)
+              runOnJS(handleTextInputFocusWhenKeyboardShow)()
+            else
+              runOnJS(handleTextInputFocusWhenKeyboardHide)()
 
           if (value === 0) {
             runOnJS(enableTyping)()
@@ -588,6 +592,7 @@ function GiftedChat<TMessage extends IMessage = IMessage> (
     [
       keyboard,
       trackingKeyboardMovement,
+      focusOnInputWhenOpeningKeyboard,
       insets,
       handleTextInputFocusWhenKeyboardHide,
       handleTextInputFocusWhenKeyboardShow,


### PR DESCRIPTION
Solves issues: https://github.com/FaridSafi/react-native-gifted-chat/issues/2548 and https://github.com/FaridSafi/react-native-gifted-chat/issues/2572