### PR TITLE
fix: Expo playground update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="https://reverent-bardeen-47c862.netlify.com/" target="_blank">Demo Web 🖥</a>
 </p>
 <p align="center">
-  <a href="https://snack.expo.io/@xcarpentier/giftedchat-playground" target="_blank">Snack GiftedChat playground</a>
+  <a href="https://snack.expo.dev/UV4_xttBKve_gwCdqjIvp" target="_blank">Snack GiftedChat playground</a>
   <img height="18" src="https://snack.expo.io/favicon.ico" />
 </p>
 


### PR DESCRIPTION
## Problem
Expo playground gifted chat is not broken.

## Solution
- Updated it with the latest Gifted chat release and updated dependencies and code.
- Updated link in README.md

<img width="1142" alt="Screenshot 2025-01-25 at 09 39 14" src="https://github.com/user-attachments/assets/007a776f-0813-422c-a569-edf79e9dc3e5" />
