### PR TITLE
Fix: adjust scroll area when keyboard is open

### DIFF
--- a/src/MessageContainer/index.tsx
+++ b/src/MessageContainer/index.tsx
@@ -13,6 +13,7 @@ import Animated, { runOnJS, useAnimatedScrollHandler, useAnimatedStyle, useShare
 import { ReanimatedScrollEvent } from 'react-native-reanimated/lib/typescript/hook/commonTypes'
 import DayAnimated from './components/DayAnimated'
 import Item from './components/Item'
+import { useReanimatedKeyboardAnimation, KeyboardProvider } from 'react-native-keyboard-controller'
 
 import { LoadEarlier } from '../LoadEarlier'
 import { IMessage } from '../types'
@@ -60,6 +61,8 @@ function MessageContainer<TMessage extends IMessage = IMessage> (props: MessageC
   const scrollToBottomStyleAnim = useAnimatedStyle(() => ({
     opacity: scrollToBottomOpacity.value,
   }), [scrollToBottomOpacity])
+
+  const keyboard = useReanimatedKeyboardAnimation()
 
   const daysPositions = useSharedValue<DaysPositions>({})
   const listHeight = useSharedValue(0)
@@ -341,48 +344,56 @@ function MessageContainer<TMessage extends IMessage = IMessage> (props: MessageC
   }, [messages, daysPositions, inverted])
 
   return (
-    <View
-      style={[
-        styles.contentContainerStyle,
-        alignTop ? styles.containerAlignTop : stylesCommon.fill,
-      ]}
-    >
-      <AnimatedFlatList
-        extraData={extraData}
-        ref={forwardRef as React.Ref<FlatList<unknown>>}
-        keyExtractor={keyExtractor}
-        data={messages}
-        renderItem={renderItem}
-        inverted={inverted}
-        automaticallyAdjustContentInsets={false}
-        style={stylesCommon.fill}
-        {...invertibleScrollViewProps}
-        ListEmptyComponent={renderChatEmpty}
-        ListFooterComponent={
-          inverted ? ListHeaderComponent : ListFooterComponent
-        }
-        ListHeaderComponent={
-          inverted ? ListFooterComponent : ListHeaderComponent
-        }
-        onScroll={scrollHandler}
-        scrollEventThrottle={1}
-        onEndReached={onEndReached}
-        onEndReachedThreshold={0.1}
-        {...listViewProps}
-        onLayout={onLayoutList}
-        CellRendererComponent={renderCell}
-      />
-      {isScrollToBottomEnabled
-        ? renderScrollToBottomWrapper()
-        : null}
-      <DayAnimated
-        scrolledY={scrolledY}
-        daysPositions={daysPositions}
-        listHeight={listHeight}
-        messages={messages}
-        isLoadingEarlier={isLoadingEarlier}
-      />
-    </View>
+    <KeyboardProvider>
+      <View
+        style={[
+          styles.contentContainerStyle,
+          alignTop ? styles.containerAlignTop : stylesCommon.fill,
+        ]}
+      >
+        <AnimatedFlatList
+          extraData={extraData}
+          ref={forwardRef as React.Ref<FlatList<unknown>>}
+          keyExtractor={keyExtractor}
+          data={messages}
+          renderItem={renderItem}
+          inverted={inverted}
+          automaticallyAdjustContentInsets={false}
+          style={stylesCommon.fill}
+          {...invertibleScrollViewProps}
+          ListEmptyComponent={renderChatEmpty}
+          ListFooterComponent={
+            inverted ? ListHeaderComponent : ListFooterComponent
+          }
+          ListHeaderComponent={
+            inverted ? ListFooterComponent : ListHeaderComponent
+          }
+          onScroll={scrollHandler}
+          scrollEventThrottle={1}
+          onEndReached={onEndReached}
+          onEndReachedThreshold={0.1}
+          {...listViewProps}
+          onLayout={onLayoutList}
+          CellRendererComponent={renderCell}
+          contentContainerStyle={[
+            {
+              paddingBottom: Math.abs(keyboard.height.value),
+            },
+            listViewProps?.contentContainerStyle,
+          ]}
+        />
+        {isScrollToBottomEnabled
+          ? renderScrollToBottomWrapper()
+          : null}
+        <DayAnimated
+          scrolledY={scrolledY}
+          daysPositions={daysPositions}
+          listHeight={listHeight}
+          messages={messages}
+          isLoadingEarlier={isLoadingEarlier}
+        />
+      </View>
+    </KeyboardProvider>
   )
 }
 

--- a/src/MessageContainer/index.tsx
+++ b/src/MessageContainer/index.tsx
@@ -377,7 +377,7 @@ function MessageContainer<TMessage extends IMessage = IMessage> (props: MessageC
           CellRendererComponent={renderCell}
           contentContainerStyle={[
             {
-              paddingBottom: Math.abs(keyboard.height.value),
+              paddingBottom: -keyboard.height.value,
             },
             listViewProps?.contentContainerStyle,
           ]}

--- a/src/MessageContainer/types.ts
+++ b/src/MessageContainer/types.ts
@@ -15,6 +15,7 @@ import { AnimateProps } from 'react-native-reanimated'
 
 export type ListViewProps = {
   onLayout?: (event: LayoutChangeEvent) => void
+  contentContainerStyle?: StyleProp<ViewStyle>
 } & object
 
 export type AnimatedList<TMessage> = Component<AnimateProps<FlatListProps<TMessage>>, unknown, unknown> & FlatList<FlatListProps<TMessage>>

--- a/src/__tests__/MessageContainer.test.tsx
+++ b/src/__tests__/MessageContainer.test.tsx
@@ -4,6 +4,13 @@ import renderer from 'react-test-renderer'
 
 import { MessageContainer } from '../GiftedChat'
 
+jest.mock('react-native-keyboard-controller', () => ({
+  useReanimatedKeyboardAnimation: () => ({
+    height: { value: 0 },
+  }),
+  KeyboardProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
 it('should render <MessageContainer /> and compare with snapshot', () => {
   const tree = renderer.create(<MessageContainer />).toJSON()
 

--- a/src/__tests__/__snapshots__/MessageContainer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/MessageContainer.test.tsx.snap
@@ -27,6 +27,14 @@ exports[`should render <MessageContainer /> and compare with snapshot 1`] = `
     }
     automaticallyAdjustContentInsets={false}
     collapsable={false}
+    contentContainerStyle={
+      [
+        {
+          "paddingBottom": -0,
+        },
+        undefined,
+      ]
+    }
     data={[]}
     extraData={null}
     getItem={[Function]}


### PR DESCRIPTION
## Summary

This PR fixes the issue where the message list could not be fully scrolled when the keyboard is open, as described in [#2527](https://github.com/FaridSafi/react-native-gifted-chat/issues/2527).

## Changes

- Wrap `MessageContainer` with `KeyboardProvider`
- Dynamically adjust `contentContainerStyle` by adding `paddingBottom` based on the keyboard height
- Update snapshot tests to reflect the intended layout changes

## Reason

Without adjusting the padding, users cannot fully scroll to the latest messages when the keyboard is visible, especially when multiple messages are displayed.

## Related Issue

- Related to [#2527](https://github.com/FaridSafi/react-native-gifted-chat/issues/2527)

## Notes

- Only affects layout behavior when the keyboard is open
- No breaking changes for existing behavior

---

Please let me know if any further adjustments are needed!