### PR TITLE
fix: improve listViewProps typing with Partial<FlatListProps>

### DIFF
--- a/src/MessageContainer/types.ts
+++ b/src/MessageContainer/types.ts
@@ -1,7 +1,6 @@
 import React, { Component, RefObject } from 'react'
 import {
   FlatListProps,
-  LayoutChangeEvent,
   StyleProp,
   ViewStyle,
 } from 'react-native'
@@ -13,9 +12,7 @@ import { ReanimatedScrollEvent } from 'react-native-reanimated/lib/typescript/ho
 import { FlatList } from 'react-native-reanimated/lib/typescript/Animated'
 import { AnimateProps } from 'react-native-reanimated'
 
-export type ListViewProps = {
-  onLayout?: (event: LayoutChangeEvent) => void
-} & object
+export type ListViewProps<TMessage extends IMessage = IMessage> = Partial<FlatListProps<TMessage>>;
 
 export type AnimatedList<TMessage> = Component<AnimateProps<FlatListProps<TMessage>>, unknown, unknown> & FlatList<FlatListProps<TMessage>>
 


### PR DESCRIPTION
Improves the type of `listViewProps` to allow safely passing any FlatList-compatible props.

Previously, `listViewProps` was typed as `{ onLayout } & object`, which caused TypeScript errors when passing valid props like:
- `style`
- `onScroll`
- `onEndReached`
- ...