### PR TITLE
Fix: Bubble component typing regression

### DIFF
--- a/src/Bubble/index.tsx
+++ b/src/Bubble/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { JSX, useCallback } from 'react'
 import {
   Text,
   TouchableWithoutFeedback,
@@ -22,7 +22,7 @@ import styles from './styles'
 
 export * from './types'
 
-const Bubble: React.FC<BubbleProps<IMessage>> = (props: BubbleProps<IMessage>) => {
+const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<TMessage>): JSX.Element => {
   const {
     currentMessage,
     nextMessage,


### PR DESCRIPTION
PR #2609 introduced a type regression by migrating the Bubble component from a class component to a function component using React.FC, which does not support generics.

This commit replaces `React.FC` with generics and a `JSX.Element` return type on the Bubble component, allowing to keep the function component and bringing back the type argument. The type argument here is necessary to provide accurate type information for non-vanilla messages.

Since generics are used quite extensively on this project especially around message object customization, I recommend to steer away from using `React.FC` for consistency's sake.

For those wanting to use a ready-to-go patch using patch-package for example, here you go:
<details>
<summary>
react-native-gifted-chat+2.8.1.patch
</summary>

```patch
diff --git a/node_modules/react-native-gifted-chat/lib/Bubble/index.d.ts b/node_modules/react-native-gifted-chat/lib/Bubble/index.d.ts
index 5a9d350..51a36b2 100644
--- a/node_modules/react-native-gifted-chat/lib/Bubble/index.d.ts
+++ b/node_modules/react-native-gifted-chat/lib/Bubble/index.d.ts
@@ -1,6 +1,6 @@
-import React from 'react';
+import { JSX } from 'react';
 import { IMessage } from '../types';
 import { BubbleProps } from './types';
 export * from './types';
-declare const Bubble: React.FC<BubbleProps<IMessage>>;
+declare const Bubble: <TMessage extends IMessage = IMessage>(props: BubbleProps<TMessage>) => JSX.Element;
 export default Bubble;
```
</details>

@kesha-antonov feel free to review and provide feedback, I might have missed some things or reasons why you decided to went with React.FC in the first place here.