### PR TITLE
feat(typing-indicator): add containerStyle prop in TypingIndicator

### DIFF
--- a/src/TypingIndicator/index.tsx
+++ b/src/TypingIndicator/index.tsx
@@ -89,14 +89,14 @@ const DotsAnimation = () => {
   )
 }
 
-const TypingIndicator = ({ isTyping }: TypingIndicatorProps) => {
+const TypingIndicator = ({ isTyping, containerStyle }: TypingIndicatorProps) => {
   const yCoords = useSharedValue(200)
   const heightScale = useSharedValue(0)
   const marginScale = useSharedValue(0)
 
   const [isVisible, setIsVisible] = useState(isTyping)
 
-  const containerStyle = useAnimatedStyle(() => ({
+  const animatedContainerStyle = useAnimatedStyle(() => ({
     transform: [
       {
         translateY: yCoords.value,
@@ -145,6 +145,7 @@ const TypingIndicator = ({ isTyping }: TypingIndicatorProps) => {
     <Animated.View
       style={[
         styles.container,
+        animatedContainerStyle,
         containerStyle,
       ]}
     >

--- a/src/TypingIndicator/types.ts
+++ b/src/TypingIndicator/types.ts
@@ -1,3 +1,6 @@
+import { StyleProp, ViewStyle } from "react-native";
+
 export interface TypingIndicatorProps {
-  isTyping?: boolean
+  isTyping?: boolean;
+  containerStyle?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
The `TypingIndicator` component previously had no way to customize its container styles. This made it difficult to modify its appearance (e.g., `backgroundColor`, `borderRadius`) to match the customized message bubble styles.

This commit introduces an optional `containerStyle` prop, allowing to apply custom styles to the component's root container. To avoid a naming conflict with the existing prop, the internal variable holding animated styles has been renamed from `containerStyle` to `animatedContainerStyle`.