### PR TITLE
Replace deprecated TouchableWithoutFeedback with Pressable

### DIFF
--- a/src/Bubble/index.tsx
+++ b/src/Bubble/index.tsx
@@ -1,7 +1,7 @@
 import React, { JSX, useCallback } from 'react'
 import {
   Text,
-  TouchableWithoutFeedback,
+  Pressable,
   View,
 } from 'react-native'
 
@@ -374,10 +374,9 @@ const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<TMessag
           wrapperStyle && wrapperStyle[position],
         ]}
       >
-        <TouchableWithoutFeedback
+        <Pressable
           onPress={onPress}
           onLongPress={onLongPress}
-          accessibilityRole='text'
           {...props.touchableProps}
         >
           <View>
@@ -393,7 +392,7 @@ const Bubble = <TMessage extends IMessage = IMessage>(props: BubbleProps<TMessag
               {renderTicks()}
             </View>
           </View>
-        </TouchableWithoutFeedback>
+        </Pressable>
       </View>
       {renderQuickReplies()}
     </View>


### PR DESCRIPTION
As described in #2666 the `TouchableWithoutFeedback` is deprecated and should be replaced with `Pressable`.