### PR TITLE
fix: add 'unspecified' to getColorScheme return type for RN 0.83 compatibility

### DIFF
--- a/src/GiftedChatContext.ts
+++ b/src/GiftedChatContext.ts
@@ -11,7 +11,7 @@ export interface IGiftedChatContext {
     ) => void
   }
   getLocale(): string
-  getColorScheme(): 'light' | 'dark' | null | undefined
+  getColorScheme(): 'light' | 'dark' | 'unspecified' | null | undefined
 }
 
 export const GiftedChatContext = createContext<IGiftedChatContext>({


### PR DESCRIPTION
## Summary

- Add `'unspecified'` to the `getColorScheme()` return type in `IGiftedChatContext` to fix a TypeScript error with React Native 0.83+
- React Native 0.83 changed `ColorSchemeName` to `'light' | 'dark' | 'unspecified'`, but the interface only allowed `'light' | 'dark' | null | undefined`
- This is a backward-compatible, additive type change — no runtime behavior changes

## Problem

```
error TS2322: Type 'ColorSchemeName' is not assignable to type '"dark" | "light" | null | undefined'.
  Type '"unspecified"' is not assignable to type '"dark" | "light" | null | undefined'.
```

Occurs at `src/GiftedChat/index.tsx` where the context provider's `getColorScheme` returns `ColorSchemeName` (which now includes `'unspecified'` in RN 0.83).

## Fix

```diff
- getColorScheme(): 'light' | 'dark' | null | undefined
+ getColorScheme(): 'light' | 'dark' | 'unspecified' | null | undefined
```

Related to #2712 (TypeScript errors in v3.3.2).

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] `yarn test` — all 22 test suites (39 tests) pass

## Environment

- `react-native`: 0.83.1
- `typescript`: 5.9.3