### PR TITLE
feat: implements messagesContainerInsets prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ function ChatScreen() {
 - **`renderLoading`** _(Component | Function)_ - Render a loading view when initializing
 - **`renderChatEmpty`** _(Component | Function)_ - Custom component to render in the ListView when messages are empty
 - **`renderChatFooter`** _(Component | Function)_ - Custom component to render below the MessagesContainer (separate from the ListView)
+- **`messagesContainerInsets`** _(Object)_ - Content insets for the messages container FlatList. Accepts `{ top, left, bottom, right }`.
 - **`listProps`** _(Object)_ - Extra props to be passed to the messages [`<FlatList>`](https://reactnative.dev/docs/flatlist). Supports all FlatList props including `maintainVisibleContentPosition` for keeping scroll position when new messages arrive (useful for AI chatbots).
 
 ### Message Bubbles & Content

--- a/src/MessagesContainer/index.tsx
+++ b/src/MessagesContainer/index.tsx
@@ -43,6 +43,7 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
     scrollToBottomComponent: scrollToBottomComponentProp,
     renderDay: renderDayProp,
     isDayAnimationEnabled = true,
+    messagesContainerInsets,
   } = props
 
   const listPropsOnScrollProp = listProps?.onScroll
@@ -397,6 +398,7 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
         renderItem={renderItem}
         inverted={isInverted}
         automaticallyAdjustContentInsets={false}
+        contentInset={messagesContainerInsets}
         style={stylesCommon.fill}
         contentContainerStyle={styles.messagesContainer}
         ListEmptyComponent={renderChatEmpty}

--- a/src/MessagesContainer/types.ts
+++ b/src/MessagesContainer/types.ts
@@ -1,6 +1,7 @@
 import { RefObject } from 'react'
 import {
   FlatListProps,
+  Insets,
   StyleProp,
   ViewStyle,
 } from 'react-native'
@@ -83,6 +84,8 @@ export interface MessagesContainerProps<TMessage extends IMessage = IMessage>
   typingIndicatorStyle?: StyleProp<ViewStyle>
   /** Enable animated day label that appears on scroll; default is true */
   isDayAnimationEnabled?: boolean
+  /** Content insets for the messages container FlatList */
+  messagesContainerInsets?: Insets
   /** Reply functionality configuration */
   reply?: ReplyProps<TMessage>
 }


### PR DESCRIPTION
This prop is needed when the GiftedChat is rendered in an iOS 26 screen with Liquid Glass / transparent header. Currently, there was no way to set the content's inset, or starting point, without margin/padding, which wouldn't allow the messages to fully go behind the header

Before (Load earlier button not visible or interactable):

https://github.com/user-attachments/assets/a1838d7e-077b-4b07-9beb-9153455b297c

After (Load earlier button visible and interactable):

https://github.com/user-attachments/assets/0547ebb0-db6e-4188-94f2-a83070f8903b

