### PR TITLE
Fix renderUsername type for strictFunctionTypes compatibility

### DIFF
--- a/src/Bubble/types.ts
+++ b/src/Bubble/types.ts
@@ -94,7 +94,7 @@ export interface BubbleProps<TMessage extends IMessage> {
   renderCustomView?: (bubbleProps: BubbleProps<TMessage>) => React.ReactNode
   renderTime?: (timeProps: TimeProps<TMessage>) => React.ReactNode
   renderTicks?: (currentMessage: TMessage) => React.ReactNode
-  renderUsername?: (user?: TMessage['user']) => React.ReactNode
+  renderUsername?: (props: TMessage['user']) => React.ReactNode
   renderQuickReplySend?: () => React.ReactNode
   renderQuickReplies?: (
     quickReplies: QuickRepliesProps<TMessage>


### PR DESCRIPTION
## Summary
- Fix TypeScript error when `strictFunctionTypes` is enabled (e.g. Expo's default tsconfig)
- `renderUsername` prop in `BubbleProps` is typed as `(user?: TMessage['user']) => ReactNode`, but gets passed to `renderComponentOrElement` which expects `(props: TProps) => ReactNode` where `TProps extends Record<string, any>`
- With strict function types, the optional parameter creates a contravariance mismatch

## The Error
```
error TS2345: Argument of type '(user?: TMessage["user"] | undefined) => ReactNode'
is not assignable to parameter of type '... | ((props: Record<string, any>) => ReactNode) | ...'
```

At `src/Bubble/index.tsx:296`:
```typescript
return renderComponentOrElement(renderUsername, currentMessage.user)
```

## Fix
One-line change in `src/Bubble/types.ts`:
```diff
- renderUsername?: (user?: TMessage['user']) => React.ReactNode
+ renderUsername?: (props: TMessage['user']) => React.ReactNode
```

The parameter was already always called with `currentMessage.user` (never `undefined`), so making it required matches actual usage. This is similar to the fixes in #2698.

## Test
- Verified typecheck passes with `strictFunctionTypes: true` and `strictNullChecks: true`
- No runtime behavior change — just a type signature correction