### PR TITLE
fix: animated day header shows wrong date while scrolling (#2709)

### DIFF
--- a/src/MessagesContainer/components/DayAnimated/index.tsx
+++ b/src/MessagesContainer/components/DayAnimated/index.tsx
@@ -46,16 +46,20 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, renderDay, m
   }, [messages])
 
   const createdAtDate = useDerivedValue(() => {
+    // Pick the day the header is currently positioned over. This must use the
+    // same threshold (day.y + day.height) and last-item fallback as
+    // `currentDayPosition` which drives the header's vertical position;
+    // otherwise the displayed date can lag the visible group by one day (#2709).
     for (let i = 0; i < daysPositionsArray.value.length; i++) {
       const day = daysPositionsArray.value[i]
-      const dayPosition = day.y + day.height - containerHeight.value - dayBottomMargin
+      const dayPosition = day.y + day.height
 
-      if (absoluteScrolledPositionToBottomOfDay.value < dayPosition)
+      if (absoluteScrolledPositionToBottomOfDay.value < dayPosition || i === daysPositionsArray.value.length - 1)
         return day.createdAt
     }
 
     return messagesDates[messagesDates.length - 1]
-  }, [daysPositionsArray, absoluteScrolledPositionToBottomOfDay, messagesDates, containerHeight, dayBottomMargin])
+  }, [daysPositionsArray, absoluteScrolledPositionToBottomOfDay, messagesDates])
 
   const style = useAnimatedStyle(() => ({
     top: interpolate(


### PR DESCRIPTION
## Fixes #2709

### Problem
While scrolling a chat with messages across multiple days, the floating **animated day header** could show the wrong date (e.g. the previous day) for the message group in view, even though the inline day separators were correct.

### Root cause
The header's **date** was selected with a different threshold than its **position**:
- Position (`currentDayPosition`): `dayPosition = day.y + day.height`
- Date (`createdAtDate`): `dayPosition = day.y + day.height − containerHeight − dayBottomMargin`

So the date switched at a different scroll point than the header's visual transition → off-by-one-day mismatch.

### Fix
Align the date selection with the position logic - same `day.y + day.height` threshold and same last-item fallback.

### Validation (Android simulator, multi-day chat)
- Floating header shows **"10 June"** over the 10 June group ✅
- Floating header shows **"17 June"** over the 17 June group ✅
- Tracks correctly across the day boundary, no off-by-one ✅

`tsc`, `eslint`, `build` pass locally; CI (Node 22 & 24) gates this PR.