### PR TITLE
fix: avoid duplicate day badge from animated header

### DIFF
--- a/src/MessagesContainer/components/DayAnimated/index.tsx
+++ b/src/MessagesContainer/components/DayAnimated/index.tsx
@@ -71,8 +71,17 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, renderDay, m
   }), [relativeScrolledPositionToBottomOfDay, containerHeight, dayTopOffset, isLoadingAnim])
 
   const contentStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
-  }), [opacity])
+    // Only show the floating header once the current day's inline separator has
+    // scrolled off the top (relativeScrolledPositionToBottomOfDay < 0). While the
+    // inline separator is still on screen (>= 0) it already shows the date, so
+    // hiding the floating copy avoids a duplicate date badge (#2709).
+    opacity: opacity.value * interpolate(
+      relativeScrolledPositionToBottomOfDay.value,
+      [-0.0001, 0],
+      [1, 0],
+      'clamp'
+    ),
+  }), [opacity, relativeScrolledPositionToBottomOfDay])
 
   const fadeOut = useCallback(() => {
     'worklet'


### PR DESCRIPTION
## Follow-up to #2709

After #2709 aligned the animated day header's **date** with the visible group, an edge case surfaced: while scrolling, the floating header could show the **same date** as the inline day separator while that separator was still on screen, producing a stacked **duplicate date badge** (two "10 June" / two "17 June").

### Fix
Gate the floating header's opacity on `relativeScrolledPositionToBottomOfDay`: show it only once the current day's inline separator has scrolled off the top (`< 0`). While the inline separator is visible (`>= 0`) it already shows the date, so the floating copy stays hidden - a clean handoff, mirroring the inline separator's own opacity flip.

### Validation (Android simulator, multi-day chat)
- Scrolling within a group: floating header shows the correct date (e.g. "10 June"), single badge ✅
- At a day boundary ("17 June" separator at top): date shown **once**, no floating/inline stack ✅
- At rest: header fades out, no duplicate ✅

`tsc`, `eslint`, `build` pass; CI (Node 22 & 24) gates this PR.