### PR TITLE
feat: expose isAnimated flag to renderDay for floating day header (#2721)

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ See full example in [LinksExample](example/components/chat-examples/LinksExample
 - **`timeFormat`** _(String)_ - Format to use for rendering times; default is `'LT'` (see [Day.js Format](https://day.js.org/docs/en/display/format))
 - **`dateFormat`** _(String)_ - Format to use for rendering dates; default is `'D MMMM'` (see [Day.js Format](https://day.js.org/docs/en/display/format))
 - **`dateFormatCalendar`** _(Object)_ - Format to use for rendering relative times; default is `{ sameDay: '[Today]' }` (see [Day.js Calendar](https://day.js.org/docs/en/plugin/calendar))
-- **`renderDay`** _(Component | Function)_ - Custom day above a message
+- **`renderDay`** _(Component | Function)_ - Custom day above a message. The same function renders both the inline day separators and the floating/animated day header that sticks to the top while scrolling. Read `props.isAnimated` (`true` for the floating header, `false` for the inline separator) to give each a different look.
 - **`dayProps`** _(Object)_ - Props to pass to the Day component:
   - `containerStyle` - Custom style for the day container
   - `wrapperStyle` - Custom style for the day wrapper

--- a/src/Day/types.ts
+++ b/src/Day/types.ts
@@ -12,4 +12,10 @@ export interface DayProps {
   wrapperStyle?: StyleProp<ViewStyle>
   /** Props to pass to the Text component (e.g., style, allowFontScaling, numberOfLines) */
   textProps?: Partial<TextProps>
+  /**
+   * `true` when rendered as the floating/animated day header that sticks to the
+   * top while scrolling, `false`/`undefined` for the inline day separators.
+   * Use this in a custom `renderDay` to give the floating header a different look.
+   */
+  isAnimated?: boolean
 }

--- a/src/MessagesContainer/components/DayAnimated/index.tsx
+++ b/src/MessagesContainer/components/DayAnimated/index.tsx
@@ -135,11 +135,12 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, renderDay, m
       return null
 
     return renderDay
-      ? renderDay({ ...rest, createdAt })
+      ? renderDay({ ...rest, createdAt, isAnimated: true })
       : <Day
         {...rest}
         containerStyle={[styles.dayAnimatedDayContainerStyle, rest.containerStyle]}
         createdAt={createdAt}
+        isAnimated
       />
   }, [createdAt, renderDay, rest])
 

--- a/src/MessagesContainer/components/Item/index.tsx
+++ b/src/MessagesContainer/components/Item/index.tsx
@@ -97,8 +97,8 @@ const DayWrapper = <TMessage extends IMessage>(props: MessageProps<TMessage>) =>
     <View>
       {
         renderDayProp
-          ? renderDayProp({ ...rest, createdAt: currentMessage.createdAt })
-          : <Day {...rest} createdAt={currentMessage.createdAt} />
+          ? renderDayProp({ ...rest, createdAt: currentMessage.createdAt, isAnimated: false })
+          : <Day {...rest} createdAt={currentMessage.createdAt} isAnimated={false} />
       }
     </View>
   )


### PR DESCRIPTION
Closes #2721

## Problem
`renderDay` is used for **both** the inline day separators and the floating/animated day header that sticks to the top while scrolling. There was no way to distinguish the two inside a custom `renderDay`, so users were forced to give both the same look.

## Fix
Pass an `isAnimated` flag in the `DayProps` handed to `renderDay`:
- `true` for the floating animated header
- `false` (or `undefined`) for the inline separators

A single `renderDay` can now branch on it:

```tsx
renderDay={(props) =>
  props.isAnimated
    ? <FloatingDayHeader {...props} />
    : <Day {...props} />
}
```

`dateFormat` / `dateFormatCalendar` already flow through to the floating header, so custom date formats stay in sync there too (the second half of the issue).

This is non-breaking - `isAnimated` is an additive optional field on `DayProps`; existing `renderDay` callbacks keep working unchanged.

## Validation
Verified on the Android emulator with a branching `renderDay`: the inline separators render one style while the floating header renders a distinct one as it appears during scroll.