### PR TITLE
fix: Telegram-style sticky day header (slide, no flash, no duplicate)

### DIFF
--- a/docs/DAY_ANIMATED_SPEC.md
+++ b/docs/DAY_ANIMATED_SPEC.md
@@ -1,0 +1,123 @@
+# DayAnimated (floating day header) - animation spec
+
+How the Telegram-style sticky day header works in this library. Describes the
+final implementation across `DayAnimated`, `Item` (inline separators),
+`MessagesContainer`, and the shared `dayLayout` constants.
+
+## 1. Reference behaviour (Telegram iOS, what we replicate)
+
+The conversation is an inverted list (newest at the bottom). Each day has a
+centered date pill. Two elements together read as one sticky header:
+
+1. **Inline separator** - a pill at the top of each day's group, scrolls with the
+   content like a normal row.
+2. **Floating header** - while you scroll, the date of the *topmost visible day*
+   sticks just under the nav bar.
+
+Behaviour:
+
+- **Scroll-gated visibility.** Hidden at rest. Fades in fast when scrolling
+  starts, stays fully opaque for the *entire gesture* (drag + momentum, including
+  slow drags and pauses), fades out shortly after motion fully stops.
+- **Which date.** The day of the messages at the top of the viewport (the "stuck"
+  day), pinned at a small offset under the nav bar.
+- **Slide, not fade.** At a day boundary the date *slides*, it never cross-fades.
+  - Scrolling into an **older** day (scroll up / toward top): the new (older) date
+    **slides down from the top edge to the pin, pixel by pixel**, as the previous
+    date slides down below it.
+  - Scrolling into a **newer** day (scroll down / toward bottom): the newer date
+    rises from below to the pin and the previous date is pushed up and off.
+  - During the transition the two dates are **different**, separated by a margin,
+    moving together. Never two of the same date; never a dip to 0; never a jump.
+- **Top of history / "Load earlier".** At the very top the oldest day is stuck.
+  Once the oldest day's own separator drops back below the pin (the "Load earlier"
+  button scrolls in) nothing is stuck: the header hands the date back to the inline
+  separator and hides - no duplicate over the loader. While actively loading, the
+  header tucks above the top edge.
+
+## 2. Structure & geometry
+
+- Inverted `FlatList`. `daysPositions` (shared value) holds, per day, the cell's
+  `{ y, height, createdAt }` measured via `onLayout`.
+- Two elements in different view trees: inline separators (`AnimatedDayWrapper` in
+  `Item`) and the floating overlay (`DayAnimated`).
+- On-screen Y of a day separator's top edge (dp):
+  `separatorScreenTop = (listHeight + scrolledY) - (day.y + day.height)`
+- The inline pill renders `DAY_MARGIN_TOP` below `separatorScreenTop` (Day's
+  container marginTop). The floating overlay overrides that margin to 0, so when it
+  is pinned at `top = DAY_PIN_OFFSET` its pill lines up exactly with an inline
+  separator whose `separatorScreenTop == DAY_PIN_OFFSET - DAY_MARGIN_TOP`. That
+  shared line is **`DAY_HANDOFF_OFFSET = DAY_PIN_OFFSET - DAY_MARGIN_TOP`**.
+  (Verified on device, all dp; the display-density factor cancels.)
+
+## 3. Mechanics (final implementation)
+
+### Stuck-day selection (`DayAnimated`, worklet)
+- `daysPositionsArray` is sorted by **`createdAt` (newest first)**, NOT by measured
+  `y`. `y` jitters while cells are (re)measured mid-scroll; sorting by date keeps
+  the selection deterministic so it can't briefly jump to the wrong neighbour.
+- The stuck day = the newest day whose `separatorScreenTop <= DAY_HANDOFF_OFFSET`.
+
+### Position - the scroll-driven slide (`DayAnimated`, worklet)
+- The floating header's `top` is positioned off the *next (newer)* day's separator:
+  `top = min(DAY_PIN_OFFSET, nextSeparatorScreenTop + DAY_MARGIN_TOP - headerHeight - DAY_PUSH_GAP)`
+- When the next separator is far below, `top = DAY_PIN_OFFSET` (pinned).
+- As the next separator nears the pin the header slides with it, pixel by pixel:
+  it slides **down from the top edge** as an older day takes over (scrolling up), or
+  is **pushed up and off** as a newer day rises (scrolling down). `DAY_PUSH_GAP`
+  keeps a margin between the outgoing and incoming pills.
+- While `isLoading`, `top = -headerHeight` (tucked above the top).
+
+### Handoff opacity - hard cutoffs (no fades)
+The date stays solid (opacity 1) through the floating <-> inline handoff because
+both sides hard-cut at the same pixel, rather than cross-fading:
+- **Inline separator** (`Item`): `opacity = (belowHandoff || !headerShowsThisDay) ? 1 : 0`
+  where `belowHandoff = separatorScreenTop > DAY_HANDOFF_OFFSET` and
+  `headerShowsThisDay = floatingRenderedDate === this day's createdAt`.
+- **Floating header `stuckGate`** (`DayAnimated`): `curSep <= DAY_HANDOFF_OFFSET ? 1 : 0`
+  (hard hide when nothing is stuck - the top-of-history / loader case).
+
+### Render gate - covering the JS-thread text lag
+The header's date *text* is React state, updated via `runOnJS`, so it lags the
+worklet by ~1 frame. Without handling, scrolling into a newer day flashes the old
+date at the pin (the header takes over on-screen there; scrolling into an older day
+it takes over off-screen, so the lag is invisible - hence the bug was top->bottom
+only). Fix:
+- `DayAnimated` publishes the date it is actually rendering to the
+  `floatingRenderedDate` shared value (a `useEffect` on the rendered `createdAt`).
+- Header `renderGate = sticky.createdAt === floatingRenderedDate ? 1 : 0` - the
+  header is hidden for any frame where its text hasn't caught up.
+- During that frame the inline separator stays up (`!headerShowsThisDay`) and shows
+  the correct date. Net: header opacity = `fade * stuckGate * renderGate`.
+
+### Visibility / fade (`DayAnimated` + `MessagesContainer`)
+- Driven by an `isScrollActive` shared value set from the scroll handler's
+  `onBeginDrag` / `onEndDrag` / `onMomentumBegin` / `onMomentumEnd` - NOT from
+  per-scroll-delta idle timers. This keeps the header at full opacity for the whole
+  gesture (slow drags and pauses included) instead of flickering out on a pause.
+- `isScrollActive` true -> fade in (`FADE_IN_DURATION`), cancel pending fade-out.
+  false -> schedule fade-out (`FADE_OUT_DELAY` then `FADE_OUT_DURATION`). A flick's
+  momentum re-asserts `isScrollActive` via `onMomentumBegin` within the delay, so it
+  stays visible through momentum.
+
+## 4. Constants (`dayLayout.ts`)
+- `DAY_PIN_OFFSET = 10` - resting top offset of the floating header.
+- `DAY_MARGIN_TOP = 5` - Day container marginTop baked into the inline rel math.
+- `DAY_HANDOFF_OFFSET = DAY_PIN_OFFSET - DAY_MARGIN_TOP` - the shared handoff line.
+- `DAY_PUSH_GAP = 8` - margin kept between the two date pills during the slide.
+- `DAY_HANDOFF_FADE = 10` - legacy; no longer used by the hard-cutoff handoff.
+
+## 5. Debug switches (`DayAnimated`, all OFF/1 for production)
+- `DEBUG_TIME_SCALE` - multiply fade durations/delay to capture fades frame-by-frame.
+- `DEBUG_FORCE_OPACITY` - keep the header at full opacity to study geometry.
+- `DEBUG_OVERLAY` - on-screen readout of `top / curSep / headerHeight / load`.
+
+## 6. Verified edge cases (Android emulator, multi-day data + Load earlier)
+- [x] Handoff between days, both directions: solid date, no dip, no duplicate, gap.
+- [x] Scroll into newer day (top->bottom): no 1-frame wrong-date flash (render gate).
+- [x] "Load earlier" at the top: no duplicate over the loader; tucks while loading;
+      correct day after prepend.
+- [x] At rest: header hidden (Telegram shows the date only while scrolling).
+- [~] Fast fling across many days: during a very fast fling the header may stay
+      hidden (render gate never settles) and the inline separators carry the dates;
+      self-corrects as scrolling slows. Acceptable.

--- a/example/app/(tabs)/explore.tsx
+++ b/example/app/(tabs)/explore.tsx
@@ -8,7 +8,7 @@ import { ThemedText } from '@/components/themed-text'
 import { ThemedView } from '@/components/themed-view'
 import { useThemeColor } from '@/hooks/use-theme-color'
 
-type ChatExample = 'basic' | 'customized-rendering' | 'slack' | 'links' | 'reply'
+type ChatExample = 'basic' | 'customized-rendering' | 'slack' | 'links' | 'reply' | 'day-animated'
 
 const examples: Array<{ id: ChatExample, title: string, description: string }> = [
   { id: 'basic', title: 'Basic Example', description: 'Basic chat with keyboard logging for testing' },
@@ -16,6 +16,7 @@ const examples: Array<{ id: ChatExample, title: string, description: string }> =
   { id: 'customized-rendering', title: 'Customized Rendering', description: 'Customized chat with all rendering options' },
   { id: 'slack', title: 'Slack Style', description: 'Slack-like message styling' },
   { id: 'reply', title: 'Reply Example', description: 'Example demonstrating reply functionality' },
+  { id: 'day-animated', title: 'Day Animated', description: 'Multi-day chat with Load earlier for testing the animated day header' },
 ]
 
 export default function ExploreScreen () {

--- a/example/app/chat/_layout.tsx
+++ b/example/app/chat/_layout.tsx
@@ -1,4 +1,4 @@
-import { TouchableOpacity, Text, StyleSheet } from 'react-native'
+import { TouchableOpacity, StyleSheet } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { Stack, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -11,11 +11,11 @@ export default function ChatLayout () {
     <Stack
       screenOptions={{
         headerShown: true,
+        headerTitleAlign: 'center',
         contentStyle: { paddingBottom: insets.bottom, backgroundColor: '#fff' },
         headerLeft: () => (
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
             <Ionicons name='chevron-back' size={24} color='#007AFF' />
-            <Text style={styles.backText}>Back</Text>
           </TouchableOpacity>
         ),
       }}
@@ -40,6 +40,10 @@ export default function ChatLayout () {
         name='slack'
         options={{ title: 'Slack Style' }}
       />
+      <Stack.Screen
+        name='day-animated'
+        options={{ title: 'Day Animated' }}
+      />
     </Stack>
   )
 }
@@ -49,9 +53,5 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginLeft: -8,
-  },
-  backText: {
-    color: '#007AFF',
-    fontSize: 17,
   },
 })

--- a/example/app/chat/day-animated.tsx
+++ b/example/app/chat/day-animated.tsx
@@ -1,0 +1,3 @@
+import DayAnimatedExample from '@/components/chat-examples/DayAnimatedExample'
+
+export default DayAnimatedExample

--- a/example/components/chat-examples/DayAnimatedExample.tsx
+++ b/example/components/chat-examples/DayAnimatedExample.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { StyleSheet, View, useColorScheme } from 'react-native'
+import { GiftedChat, IMessage } from 'react-native-gifted-chat'
+import { useKeyboardVerticalOffset } from '../../hooks/useKeyboardVerticalOffset'
+import { getColorSchemeStyle } from '../../utils/styleUtils'
+
+// Generates a labelled chat spanning several days so the floating/animated day
+// header and the inline day separators can be exercised. Each "day" is a fixed
+// number of days before today with a handful of messages, alternating sides.
+const MESSAGES_PER_DAY = 6
+const INITIAL_DAYS = 4
+const LOAD_EARLIER_DAYS = 3
+
+const generateDay = (dayOffset: number): IMessage[] => {
+  const messages: IMessage[] = []
+  for (let m = MESSAGES_PER_DAY - 1; m >= 0; m--) {
+    const createdAt = new Date()
+    createdAt.setDate(createdAt.getDate() - dayOffset)
+    createdAt.setHours(10, m, 0, 0)
+    const fromMe = m % 2 === 0
+    messages.push({
+      _id: `day-${dayOffset}-msg-${m}`,
+      text: `Day -${dayOffset} · message ${m}`,
+      createdAt,
+      user: fromMe
+        ? { _id: 1, name: 'Developer' }
+        : { _id: 2, name: 'John Doe' },
+    })
+  }
+  return messages
+}
+
+// Inclusive range of day offsets, newest message first (descending createdAt).
+const generateRange = (fromDayOffset: number, toDayOffset: number): IMessage[] => {
+  let messages: IMessage[] = []
+  for (let day = fromDayOffset; day <= toDayOffset; day++)
+    messages = messages.concat(generateDay(day))
+
+  return messages.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
+}
+
+export default function DayAnimatedExample () {
+  const [messages, setMessages] = useState<IMessage[]>(() => generateRange(0, INITIAL_DAYS - 1))
+  const [oldestDayOffset, setOldestDayOffset] = useState(INITIAL_DAYS - 1)
+  const [isLoadingEarlier, setIsLoadingEarlier] = useState(false)
+  const colorScheme = useColorScheme()
+
+  const keyboardVerticalOffset = useKeyboardVerticalOffset()
+
+  const user = useMemo(() => ({
+    _id: 1,
+    name: 'Developer',
+  }), [])
+
+  const onSend = useCallback((newMessages: IMessage[] = []) => {
+    setMessages(previousMessages => GiftedChat.append(previousMessages, newMessages))
+  }, [])
+
+  const onPressLoadEarlierMessages = useCallback(() => {
+    setIsLoadingEarlier(true)
+    setTimeout(() => {
+      const from = oldestDayOffset + 1
+      const to = oldestDayOffset + LOAD_EARLIER_DAYS
+      setMessages(previousMessages =>
+        GiftedChat.prepend(previousMessages, generateRange(from, to))
+      )
+      setOldestDayOffset(to)
+      setIsLoadingEarlier(false)
+    }, 1500)
+  }, [oldestDayOffset])
+
+  return (
+    <View style={[styles.container, getColorSchemeStyle(styles, 'container', colorScheme)]}>
+      <GiftedChat
+        messages={messages}
+        onSend={onSend}
+        user={user}
+        loadEarlierMessagesProps={{
+          isAvailable: true,
+          isLoading: isLoadingEarlier,
+          onPress: onPressLoadEarlierMessages,
+        }}
+        messagesContainerStyle={getColorSchemeStyle(styles, 'messagesContainer', colorScheme)}
+        textInputProps={{
+          style: getColorSchemeStyle(styles, 'composer', colorScheme),
+        }}
+        keyboardAvoidingViewProps={{ keyboardVerticalOffset }}
+        isScrollToBottomEnabled
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  container_dark: {
+    backgroundColor: '#000',
+  },
+  messagesContainer_dark: {
+    backgroundColor: '#000',
+  },
+  composer_dark: {
+    backgroundColor: '#1a1a1a',
+    color: '#fff',
+  },
+})

--- a/src/MessagesContainer/components/DayAnimated/debug.tsx
+++ b/src/MessagesContainer/components/DayAnimated/debug.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react'
+import { StyleSheet, Text } from 'react-native'
+import { runOnJS, useAnimatedReaction } from 'react-native-reanimated'
+
+// Debug switches for the animated day header. All OFF/1 for production - flip them
+// here when working on the animation.
+export const DAY_DEBUG = {
+  // Multiply the fade durations/delay so the fades can be captured frame-by-frame.
+  timeScale: 1,
+  // Keep the floating header at full opacity (ignore the scroll fade) so the
+  // slide/push geometry can be studied independently of the fade.
+  forceOpacity: false,
+  // Render an on-screen readout of the sticky worklet values.
+  overlay: false,
+}
+
+// On-screen readout for the header, driven by a worklet `select` that returns the
+// readout string. Returns null (and runs nothing) when DAY_DEBUG.overlay is off.
+export function useDayDebugOverlay (select: () => string, deps: unknown[]): React.ReactElement | null {
+  const [text, setText] = useState('')
+
+  useAnimatedReaction(
+    () => (DAY_DEBUG.overlay ? select() : ''),
+    value => {
+      if (value)
+        runOnJS(setText)(value)
+    },
+    deps
+  )
+
+  if (!DAY_DEBUG.overlay)
+    return null
+
+  return <Text style={styles.overlay}>{text}</Text>
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 2,
+    left: 4,
+    fontSize: 11,
+    color: 'red',
+    zIndex: 9999,
+    backgroundColor: 'rgba(255,255,255,0.8)',
+  },
+})

--- a/src/MessagesContainer/components/DayAnimated/index.tsx
+++ b/src/MessagesContainer/components/DayAnimated/index.tsx
@@ -1,34 +1,23 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { LayoutChangeEvent, Text } from 'react-native'
-import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, useAnimatedReaction, withTiming, runOnJS } from 'react-native-reanimated'
+import React, { useEffect, useMemo, useState, useCallback } from 'react'
+import { LayoutChangeEvent } from 'react-native'
+import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, useAnimatedReaction, runOnJS } from 'react-native-reanimated'
 import { Day } from '../../../Day'
 import stylesCommon from '../../../styles'
-import { DAY_HANDOFF_OFFSET, DAY_MARGIN_TOP, DAY_PIN_OFFSET, DAY_PUSH_GAP } from '../dayLayout'
+import { DAY_HANDOFF_OFFSET, DAY_MARGIN_TOP, DAY_PIN_OFFSET, DAY_PUSH_GAP, dayPositionScreenTop } from '../dayLayout'
+import { DAY_DEBUG, useDayDebugOverlay } from './debug'
 import styles from './styles'
 import { DayAnimatedProps } from './types'
+import { useScrollGatedOpacity } from './useScrollGatedOpacity'
 
 export * from './types'
 
-// --- Debug switches (all OFF/1 for production) ---------------------------------
-// Multiply fade durations/delay so the fades can be captured frame-by-frame.
-const DEBUG_TIME_SCALE = 1
-// Keep the floating header at full opacity (ignore the scroll fade) so the push
-// geometry can be studied independently of the fade.
-const DEBUG_FORCE_OPACITY = false
-// Render an on-screen readout of the sticky worklet values.
-const DEBUG_OVERLAY = false
-// -------------------------------------------------------------------------------
-
-const FADE_IN_DURATION = 150 * DEBUG_TIME_SCALE
-const FADE_OUT_DURATION = 300 * DEBUG_TIME_SCALE
-const FADE_OUT_DELAY = 600 * DEBUG_TIME_SCALE
-
 export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActive, floatingRenderedDate, renderDay, isLoading, ...rest }: DayAnimatedProps) => {
-  const opacity = useSharedValue(0)
-  const fadeOutOpacityTimeoutId = useSharedValue<ReturnType<typeof setTimeout> | undefined>(undefined)
   const containerHeight = useSharedValue(0)
-
   const isLoadingAnim = useSharedValue(isLoading)
+
+  // Telegram only shows the floating date while scrolling; this opacity fades in on
+  // scroll start and out after the gesture fully ends.
+  const opacity = useScrollGatedOpacity(isScrollActive)
 
   // Sort newest day first. Sorting by createdAt (stable) rather than measured y
   // keeps the order deterministic even while cells are (re)measured mid-scroll, so
@@ -44,23 +33,19 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
   // Telegram-style sticky day header (iOS section-header behaviour).
   //
   // The list is inverted: older days sit higher on screen, newer days lower.
-  // `daysPositionsArray` is sorted ascending by y, so index 0 is the newest day.
-  //
-  // For each day separator the on-screen Y of its top edge is:
-  //   separatorScreenTop = (listHeight + scrolledY) - (day.y + day.height)
-  // and the separator's pill renders DAY_MARGIN_TOP below that (Day's container
-  // marginTop). The floating header overrides that margin to 0, so when it is
-  // pinned at DAY_PIN_OFFSET its pill lines up with an inline separator whose
-  // separatorScreenTop === DAY_HANDOFF_OFFSET (= DAY_PIN_OFFSET - DAY_MARGIN_TOP).
+  // `daysPositionsArray` is sorted by createdAt (newest first), so index 0 is the
+  // newest day. Each separator's on-screen top edge is `dayPositionScreenTop`; the
+  // separator's pill renders DAY_MARGIN_TOP below that, and the floating header
+  // overrides that margin to 0, so its pinned pill (top = DAY_PIN_OFFSET) lines up
+  // with an inline separator at separatorScreenTop === DAY_HANDOFF_OFFSET.
   //
   // A day becomes "stuck" (shown by the floating header) the instant its separator
-  // reaches the handoff line (separatorScreenTop <= DAY_HANDOFF_OFFSET). At that same
-  // pixel the inline separator hard-cuts off (see Item) and the floating hard-cuts
-  // on, so the date hands off floating<->inline with no fade and no duplicate. The
-  // floating is then positioned by the next (newer) day's separator so it slides
-  // pixel by pixel:
-  //   top = min(DAY_PIN_OFFSET, nextSeparatorScreenTop + DAY_MARGIN_TOP - headerHeight - DAY_PUSH_GAP)
-  // so the outgoing pill keeps a DAY_PUSH_GAP margin above the rising pill.
+  // reaches the handoff line. At that same pixel the inline separator hard-cuts off
+  // (see Item) and the floating hard-cuts on - the date hands off floating<->inline
+  // with no fade and no duplicate. The floating is then positioned off the next
+  // (newer) day's separator so it slides pixel by pixel: down from the top edge as
+  // an older day takes over (scrolling up), or up and off as a newer day rises
+  // (scrolling down), keeping a DAY_PUSH_GAP margin between the two pills.
   const sticky = useDerivedValue(() => {
     'worklet'
 
@@ -71,32 +56,22 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
 
     const scrolledTop = listHeight.value + scrolledY.value
 
-    // The stuck day is the newest day whose separator has reached/passed the
-    // handoff line (DAY_HANDOFF_OFFSET). The floating header shows its date.
     let idx = n - 1
-    for (let i = 0; i < n; i++) {
-      const separatorScreenTop = scrolledTop - (days[i].y + days[i].height)
-      if (separatorScreenTop <= DAY_HANDOFF_OFFSET) {
+    for (let i = 0; i < n; i++)
+      if (dayPositionScreenTop(scrolledTop, days[i]) <= DAY_HANDOFF_OFFSET) {
         idx = i
         break
       }
-    }
 
     const current = days[idx]
-    const curSep = scrolledTop - (current.y + current.height)
+    const curSep = dayPositionScreenTop(scrolledTop, current)
 
     if (isLoadingAnim.value)
       return { top: -containerHeight.value, createdAt: current.createdAt, curSep }
 
-    // Scroll-driven slide: the floating header is positioned off the next (newer)
-    // day's separator. When that separator is far below, the header rests at the
-    // pin. As it rises/descends near the pin the header slides with it pixel by
-    // pixel - sliding down from the top edge as an older day takes over (scrolling
-    // up), or being pushed up and off as a newer day rises (scrolling down) - while
-    // keeping a DAY_PUSH_GAP margin between the two date pills.
     let top = DAY_PIN_OFFSET
     if (idx > 0) {
-      const nextSep = scrolledTop - (days[idx - 1].y + days[idx - 1].height)
+      const nextSep = dayPositionScreenTop(scrolledTop, days[idx - 1])
       top = Math.min(DAY_PIN_OFFSET, nextSep + DAY_MARGIN_TOP - containerHeight.value - DAY_PUSH_GAP)
     }
 
@@ -108,9 +83,9 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
   }), [sticky])
 
   const contentStyle = useAnimatedStyle(() => {
-    // Telegram only shows the sticky date while scrolling; that fade is driven by
-    // the scroll reaction below.
-    const fade = DEBUG_FORCE_OPACITY ? 1 : opacity.value
+    // The scroll-gated fade (see useScrollGatedOpacity); DAY_DEBUG.forceOpacity pins
+    // it to 1 so the slide/push can be studied without the fade.
+    const fade = DAY_DEBUG.forceOpacity ? 1 : opacity.value
 
     // stuckGate hides the floating header when no day is actually stuck above the
     // pin - i.e. at the top of history, once the oldest day's own separator drops
@@ -129,42 +104,9 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
     return { opacity: fade * stuckGate * renderGate }
   }, [opacity, sticky, floatingRenderedDate])
 
-  const fadeOut = useCallback(() => {
-    'worklet'
-
-    opacity.value = withTiming(0, { duration: FADE_OUT_DURATION })
-  }, [opacity])
-
-  const scheduleFadeOut = useCallback(() => {
-    clearTimeout(fadeOutOpacityTimeoutId.value)
-
-    fadeOutOpacityTimeoutId.value = setTimeout(fadeOut, FADE_OUT_DELAY)
-  }, [fadeOut, fadeOutOpacityTimeoutId])
-
   const handleLayout = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
     containerHeight.value = nativeEvent.layout.height
   }, [containerHeight])
-
-  // Telegram keeps the date header visible for the whole gesture: it fades in when
-  // scrolling starts and only fades out once scrolling fully stops (finger up AND
-  // momentum finished). Driving this from the scroll-active flag - rather than per
-  // scroll-delta idle timers - keeps it at full opacity during slow drags and short
-  // pauses instead of flickering out and back in.
-  useAnimatedReaction(
-    () => isScrollActive.value,
-    (active, prevActive) => {
-      if (active === prevActive)
-        return
-
-      if (active) {
-        clearTimeout(fadeOutOpacityTimeoutId.value)
-        opacity.value = withTiming(1, { duration: FADE_IN_DURATION })
-      } else {
-        runOnJS(scheduleFadeOut)()
-      }
-    },
-    [isScrollActive, scheduleFadeOut, fadeOutOpacityTimeoutId]
-  )
 
   useAnimatedReaction(
     () => sticky.value.createdAt,
@@ -175,15 +117,12 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
     [sticky]
   )
 
-  const [dbg, setDbg] = useState('')
-  useAnimatedReaction(
-    () => sticky.value,
-    v => {
-      if (DEBUG_OVERLAY)
-        runOnJS(setDbg)(`top=${Math.round(v.top)} cur=${Math.round(v.curSep)} ch=${Math.round(containerHeight.value)} load=${isLoadingAnim.value ? 1 : 0}`)
-    },
-    [sticky, containerHeight, isLoadingAnim]
-  )
+  const debugOverlay = useDayDebugOverlay(() => {
+    'worklet'
+
+    const v = sticky.value
+    return `top=${Math.round(v.top)} cur=${Math.round(v.curSep)} ch=${Math.round(containerHeight.value)} load=${isLoadingAnim.value ? 1 : 0}`
+  }, [sticky, containerHeight, isLoadingAnim])
 
   useEffect(() => {
     isLoadingAnim.value = isLoading
@@ -194,7 +133,6 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
   useEffect(() => {
     floatingRenderedDate.value = createdAt
   }, [createdAt, floatingRenderedDate])
-
 
   const dayContent = useMemo(() => {
     if (!createdAt)
@@ -209,12 +147,6 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActi
         isAnimated
       />
   }, [createdAt, renderDay, rest])
-
-  const debugOverlay = DEBUG_OVERLAY
-    ? (
-      <Text style={{ position: 'absolute', top: 2, left: 4, fontSize: 11, color: 'red', zIndex: 9999, backgroundColor: 'rgba(255,255,255,0.8)' }}>{dbg}</Text>
-    )
-    : null
 
   if (!createdAt)
     return debugOverlay

--- a/src/MessagesContainer/components/DayAnimated/index.tsx
+++ b/src/MessagesContainer/components/DayAnimated/index.tsx
@@ -1,134 +1,200 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { LayoutChangeEvent } from 'react-native'
-import Animated, { interpolate, useAnimatedStyle, useDerivedValue, useSharedValue, useAnimatedReaction, withTiming, runOnJS } from 'react-native-reanimated'
+import { LayoutChangeEvent, Text } from 'react-native'
+import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, useAnimatedReaction, withTiming, runOnJS } from 'react-native-reanimated'
 import { Day } from '../../../Day'
 import stylesCommon from '../../../styles'
-import { isSameDay } from '../../../utils'
-import { useAbsoluteScrolledPositionToBottomOfDay, useRelativeScrolledPositionToBottomOfDay } from '../Item'
+import { DAY_HANDOFF_OFFSET, DAY_MARGIN_TOP, DAY_PIN_OFFSET, DAY_PUSH_GAP } from '../dayLayout'
 import styles from './styles'
 import { DayAnimatedProps } from './types'
 
 export * from './types'
 
-export const DayAnimated = ({ scrolledY, daysPositions, listHeight, renderDay, messages, isLoading, ...rest }: DayAnimatedProps) => {
+// --- Debug switches (all OFF/1 for production) ---------------------------------
+// Multiply fade durations/delay so the fades can be captured frame-by-frame.
+const DEBUG_TIME_SCALE = 1
+// Keep the floating header at full opacity (ignore the scroll fade) so the push
+// geometry can be studied independently of the fade.
+const DEBUG_FORCE_OPACITY = false
+// Render an on-screen readout of the sticky worklet values.
+const DEBUG_OVERLAY = false
+// -------------------------------------------------------------------------------
+
+const FADE_IN_DURATION = 150 * DEBUG_TIME_SCALE
+const FADE_OUT_DURATION = 300 * DEBUG_TIME_SCALE
+const FADE_OUT_DELAY = 600 * DEBUG_TIME_SCALE
+
+export const DayAnimated = ({ scrolledY, daysPositions, listHeight, isScrollActive, floatingRenderedDate, renderDay, isLoading, ...rest }: DayAnimatedProps) => {
   const opacity = useSharedValue(0)
   const fadeOutOpacityTimeoutId = useSharedValue<ReturnType<typeof setTimeout> | undefined>(undefined)
   const containerHeight = useSharedValue(0)
 
-  const isScrolledOnMount = useSharedValue(false)
   const isLoadingAnim = useSharedValue(isLoading)
 
+  // Sort newest day first. Sorting by createdAt (stable) rather than measured y
+  // keeps the order deterministic even while cells are (re)measured mid-scroll, so
+  // the stuck-day selection below can't briefly jump to the wrong day.
   const daysPositionsArray = useDerivedValue(() => Object.values(daysPositions.value).sort((a, b) => {
     'worklet'
 
-    return a.y - b.y
+    return b.createdAt - a.createdAt
   }))
 
   const [createdAt, setCreatedAt] = useState<number | undefined>()
 
-  const dayTopOffset = useMemo(() => 10, [])
-  const dayBottomMargin = useMemo(() => 10, [])
-  const absoluteScrolledPositionToBottomOfDay = useAbsoluteScrolledPositionToBottomOfDay(listHeight, scrolledY, containerHeight, dayBottomMargin, dayTopOffset)
-  const relativeScrolledPositionToBottomOfDay = useRelativeScrolledPositionToBottomOfDay(listHeight, scrolledY, daysPositions, containerHeight, dayBottomMargin, dayTopOffset)
+  // Telegram-style sticky day header (iOS section-header behaviour).
+  //
+  // The list is inverted: older days sit higher on screen, newer days lower.
+  // `daysPositionsArray` is sorted ascending by y, so index 0 is the newest day.
+  //
+  // For each day separator the on-screen Y of its top edge is:
+  //   separatorScreenTop = (listHeight + scrolledY) - (day.y + day.height)
+  // and the separator's pill renders DAY_MARGIN_TOP below that (Day's container
+  // marginTop). The floating header overrides that margin to 0, so when it is
+  // pinned at DAY_PIN_OFFSET its pill lines up with an inline separator whose
+  // separatorScreenTop === DAY_HANDOFF_OFFSET (= DAY_PIN_OFFSET - DAY_MARGIN_TOP).
+  //
+  // A day becomes "stuck" (shown by the floating header) the instant its separator
+  // reaches the handoff line (separatorScreenTop <= DAY_HANDOFF_OFFSET). At that same
+  // pixel the inline separator hard-cuts off (see Item) and the floating hard-cuts
+  // on, so the date hands off floating<->inline with no fade and no duplicate. The
+  // floating is then positioned by the next (newer) day's separator so it slides
+  // pixel by pixel:
+  //   top = min(DAY_PIN_OFFSET, nextSeparatorScreenTop + DAY_MARGIN_TOP - headerHeight - DAY_PUSH_GAP)
+  // so the outgoing pill keeps a DAY_PUSH_GAP margin above the rising pill.
+  const sticky = useDerivedValue(() => {
+    'worklet'
 
-  const messagesDates = useMemo(() => {
-    const messagesDates: number[] = []
+    const days = daysPositionsArray.value
+    const n = days.length
+    if (n === 0)
+      return { top: DAY_PIN_OFFSET, createdAt: undefined as number | undefined, curSep: NaN }
 
-    for (let i = 1; i < messages.length; i++) {
-      const previousMessage = messages[i - 1]
-      const message = messages[i]
+    const scrolledTop = listHeight.value + scrolledY.value
 
-      if (!isSameDay(previousMessage, message) || !messagesDates.includes(new Date(message.createdAt).getTime()))
-        messagesDates.push(new Date(message.createdAt).getTime())
+    // The stuck day is the newest day whose separator has reached/passed the
+    // handoff line (DAY_HANDOFF_OFFSET). The floating header shows its date.
+    let idx = n - 1
+    for (let i = 0; i < n; i++) {
+      const separatorScreenTop = scrolledTop - (days[i].y + days[i].height)
+      if (separatorScreenTop <= DAY_HANDOFF_OFFSET) {
+        idx = i
+        break
+      }
     }
 
-    return messagesDates
-  }, [messages])
+    const current = days[idx]
+    const curSep = scrolledTop - (current.y + current.height)
 
-  const createdAtDate = useDerivedValue(() => {
-    // Pick the day the header is currently positioned over. This must use the
-    // same threshold (day.y + day.height) and last-item fallback as
-    // `currentDayPosition` which drives the header's vertical position;
-    // otherwise the displayed date can lag the visible group by one day (#2709).
-    for (let i = 0; i < daysPositionsArray.value.length; i++) {
-      const day = daysPositionsArray.value[i]
-      const dayPosition = day.y + day.height
+    if (isLoadingAnim.value)
+      return { top: -containerHeight.value, createdAt: current.createdAt, curSep }
 
-      if (absoluteScrolledPositionToBottomOfDay.value < dayPosition || i === daysPositionsArray.value.length - 1)
-        return day.createdAt
+    // Scroll-driven slide: the floating header is positioned off the next (newer)
+    // day's separator. When that separator is far below, the header rests at the
+    // pin. As it rises/descends near the pin the header slides with it pixel by
+    // pixel - sliding down from the top edge as an older day takes over (scrolling
+    // up), or being pushed up and off as a newer day rises (scrolling down) - while
+    // keeping a DAY_PUSH_GAP margin between the two date pills.
+    let top = DAY_PIN_OFFSET
+    if (idx > 0) {
+      const nextSep = scrolledTop - (days[idx - 1].y + days[idx - 1].height)
+      top = Math.min(DAY_PIN_OFFSET, nextSep + DAY_MARGIN_TOP - containerHeight.value - DAY_PUSH_GAP)
     }
 
-    return messagesDates[messagesDates.length - 1]
-  }, [daysPositionsArray, absoluteScrolledPositionToBottomOfDay, messagesDates])
+    return { top, createdAt: current.createdAt, curSep }
+  }, [daysPositionsArray, listHeight, scrolledY, containerHeight, isLoadingAnim])
 
   const style = useAnimatedStyle(() => ({
-    top: interpolate(
-      relativeScrolledPositionToBottomOfDay.value,
-      [-dayTopOffset, -0.0001, 0, isLoadingAnim.value ? 0 : containerHeight.value + dayTopOffset],
-      [dayTopOffset, dayTopOffset, -containerHeight.value, isLoadingAnim.value ? -containerHeight.value : dayTopOffset],
-      'clamp'
-    ),
-  }), [relativeScrolledPositionToBottomOfDay, containerHeight, dayTopOffset, isLoadingAnim])
+    top: sticky.value.top,
+  }), [sticky])
 
-  const contentStyle = useAnimatedStyle(() => ({
-    // Only show the floating header once the current day's inline separator has
-    // scrolled off the top (relativeScrolledPositionToBottomOfDay < 0). While the
-    // inline separator is still on screen (>= 0) it already shows the date, so
-    // hiding the floating copy avoids a duplicate date badge (#2709).
-    opacity: opacity.value * interpolate(
-      relativeScrolledPositionToBottomOfDay.value,
-      [-0.0001, 0],
-      [1, 0],
-      'clamp'
-    ),
-  }), [opacity, relativeScrolledPositionToBottomOfDay])
+  const contentStyle = useAnimatedStyle(() => {
+    // Telegram only shows the sticky date while scrolling; that fade is driven by
+    // the scroll reaction below.
+    const fade = DEBUG_FORCE_OPACITY ? 1 : opacity.value
+
+    // stuckGate hides the floating header when no day is actually stuck above the
+    // pin - i.e. at the top of history, once the oldest day's own separator drops
+    // back below the pin (e.g. the "Load earlier" button scrolls in). It is a hard
+    // step (not a fade) so the date hands off floating->inline at the same pixel
+    // with no fading duplicate over the loader, mirroring the inline separator's
+    // hard cutoff.
+    const stuckGate = sticky.value.curSep <= DAY_HANDOFF_OFFSET ? 1 : 0
+
+    // renderGate hides the header while its rendered text hasn't caught up to the
+    // worklet's current stuck day (the ~1-frame JS-thread lag after a day change).
+    // The inline separator stays up during this frame and shows the correct date, so
+    // the header never flashes the previous date when scrolling into a newer day.
+    const renderGate = sticky.value.createdAt === floatingRenderedDate.value ? 1 : 0
+
+    return { opacity: fade * stuckGate * renderGate }
+  }, [opacity, sticky, floatingRenderedDate])
 
   const fadeOut = useCallback(() => {
     'worklet'
 
-    opacity.value = withTiming(0, { duration: 500 })
+    opacity.value = withTiming(0, { duration: FADE_OUT_DURATION })
   }, [opacity])
 
   const scheduleFadeOut = useCallback(() => {
     clearTimeout(fadeOutOpacityTimeoutId.value)
 
-    fadeOutOpacityTimeoutId.value = setTimeout(fadeOut, 500)
+    fadeOutOpacityTimeoutId.value = setTimeout(fadeOut, FADE_OUT_DELAY)
   }, [fadeOut, fadeOutOpacityTimeoutId])
 
   const handleLayout = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
     containerHeight.value = nativeEvent.layout.height
   }, [containerHeight])
 
+  // Telegram keeps the date header visible for the whole gesture: it fades in when
+  // scrolling starts and only fades out once scrolling fully stops (finger up AND
+  // momentum finished). Driving this from the scroll-active flag - rather than per
+  // scroll-delta idle timers - keeps it at full opacity during slow drags and short
+  // pauses instead of flickering out and back in.
   useAnimatedReaction(
-    () => [scrolledY.value, daysPositionsArray],
-    (value, prevValue) => {
-      if (!isScrolledOnMount.value) {
-        isScrolledOnMount.value = true
+    () => isScrollActive.value,
+    (active, prevActive) => {
+      if (active === prevActive)
         return
+
+      if (active) {
+        clearTimeout(fadeOutOpacityTimeoutId.value)
+        opacity.value = withTiming(1, { duration: FADE_IN_DURATION })
+      } else {
+        runOnJS(scheduleFadeOut)()
       }
-
-      if (value[0] === prevValue?.[0])
-        return
-
-      opacity.value = withTiming(1, { duration: 500 })
-
-      runOnJS(scheduleFadeOut)()
     },
-    [scrolledY, scheduleFadeOut, daysPositionsArray]
+    [isScrollActive, scheduleFadeOut, fadeOutOpacityTimeoutId]
   )
 
   useAnimatedReaction(
-    () => createdAtDate.value,
+    () => sticky.value.createdAt,
     (value, prevValue) => {
       if (value && value !== prevValue)
         runOnJS(setCreatedAt)(value)
     },
-    [createdAtDate]
+    [sticky]
+  )
+
+  const [dbg, setDbg] = useState('')
+  useAnimatedReaction(
+    () => sticky.value,
+    v => {
+      if (DEBUG_OVERLAY)
+        runOnJS(setDbg)(`top=${Math.round(v.top)} cur=${Math.round(v.curSep)} ch=${Math.round(containerHeight.value)} load=${isLoadingAnim.value ? 1 : 0}`)
+    },
+    [sticky, containerHeight, isLoadingAnim]
   )
 
   useEffect(() => {
     isLoadingAnim.value = isLoading
   }, [isLoadingAnim, isLoading])
+
+  // Publish the date the header is actually rendering so the inline separators (and
+  // the header's own renderGate) know when the text has caught up to the worklet.
+  useEffect(() => {
+    floatingRenderedDate.value = createdAt
+  }, [createdAt, floatingRenderedDate])
+
 
   const dayContent = useMemo(() => {
     if (!createdAt)
@@ -144,21 +210,30 @@ export const DayAnimated = ({ scrolledY, daysPositions, listHeight, renderDay, m
       />
   }, [createdAt, renderDay, rest])
 
+  const debugOverlay = DEBUG_OVERLAY
+    ? (
+      <Text style={{ position: 'absolute', top: 2, left: 4, fontSize: 11, color: 'red', zIndex: 9999, backgroundColor: 'rgba(255,255,255,0.8)' }}>{dbg}</Text>
+    )
+    : null
+
   if (!createdAt)
-    return null
+    return debugOverlay
 
   return (
-    <Animated.View
-      style={[stylesCommon.centerItems, styles.dayAnimated, style]}
-      onLayout={handleLayout}
-      pointerEvents='none'
-    >
+    <>
+      {debugOverlay}
       <Animated.View
-        style={contentStyle}
+        style={[stylesCommon.centerItems, styles.dayAnimated, style]}
+        onLayout={handleLayout}
         pointerEvents='none'
       >
-        {dayContent}
+        <Animated.View
+          style={contentStyle}
+          pointerEvents='none'
+        >
+          {dayContent}
+        </Animated.View>
       </Animated.View>
-    </Animated.View>
+    </>
   )
 }

--- a/src/MessagesContainer/components/DayAnimated/types.ts
+++ b/src/MessagesContainer/components/DayAnimated/types.ts
@@ -1,12 +1,14 @@
 import { DayProps } from '../../../Day'
-import { IMessage } from '../../../Models'
 import { DaysPositions } from '../../types'
 
 export interface DayAnimatedProps extends Omit<DayProps, 'createdAt'> {
   scrolledY: { value: number }
   daysPositions: { value: DaysPositions }
   listHeight: { value: number }
+  isScrollActive: { value: boolean }
+  // Mirror of the date the floating header is currently rendering. The header writes
+  // it; the inline separators read it to cover the header's 1-frame text lag.
+  floatingRenderedDate: { value: number | undefined }
   renderDay?: (props: DayProps) => React.ReactNode
-  messages: IMessage[]
   isLoading: boolean
 }

--- a/src/MessagesContainer/components/DayAnimated/useScrollGatedOpacity.ts
+++ b/src/MessagesContainer/components/DayAnimated/useScrollGatedOpacity.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react'
+import { runOnJS, useAnimatedReaction, useSharedValue, withTiming } from 'react-native-reanimated'
+import { DAY_DEBUG } from './debug'
+
+const FADE_IN_DURATION = 150
+const FADE_OUT_DURATION = 300
+const FADE_OUT_DELAY = 600
+
+// Opacity (0..1) that follows the scroll gesture, Telegram-style: the floating date
+// header is hidden at rest, fades in fast when scrolling starts, stays fully opaque
+// for the whole gesture (drag + momentum, including slow drags and short pauses),
+// and fades out a short delay after scrolling fully stops. Driven by the
+// `isScrollActive` flag (begin/end drag + momentum) rather than per-scroll-delta
+// idle timers, so a pause mid-drag doesn't flicker it out and back in.
+export function useScrollGatedOpacity (isScrollActive: { value: boolean }) {
+  const opacity = useSharedValue(0)
+  const fadeOutTimeoutId = useSharedValue<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const fadeOut = useCallback(() => {
+    'worklet'
+
+    opacity.value = withTiming(0, { duration: FADE_OUT_DURATION * DAY_DEBUG.timeScale })
+  }, [opacity])
+
+  const scheduleFadeOut = useCallback(() => {
+    clearTimeout(fadeOutTimeoutId.value)
+
+    fadeOutTimeoutId.value = setTimeout(fadeOut, FADE_OUT_DELAY * DAY_DEBUG.timeScale)
+  }, [fadeOut, fadeOutTimeoutId])
+
+  useAnimatedReaction(
+    () => isScrollActive.value,
+    (active, prevActive) => {
+      if (active === prevActive)
+        return
+
+      if (active) {
+        clearTimeout(fadeOutTimeoutId.value)
+        opacity.value = withTiming(1, { duration: FADE_IN_DURATION * DAY_DEBUG.timeScale })
+      } else {
+        runOnJS(scheduleFadeOut)()
+      }
+    },
+    [isScrollActive, scheduleFadeOut, fadeOutTimeoutId]
+  )
+
+  return opacity
+}

--- a/src/MessagesContainer/components/Item/index.tsx
+++ b/src/MessagesContainer/components/Item/index.tsx
@@ -1,80 +1,14 @@
-import React, { useCallback, useMemo } from 'react'
-import { LayoutChangeEvent, View } from 'react-native'
-import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated'
+import React, { useMemo } from 'react'
+import { View } from 'react-native'
+import Animated, { useAnimatedStyle, useDerivedValue } from 'react-native-reanimated'
 import { Day } from '../../../Day'
 import { Message, MessageProps } from '../../../Message'
 import { IMessage } from '../../../Models'
 import { isSameDay } from '../../../utils'
-import { DaysPositions } from '../../types'
-import { DAY_HANDOFF_OFFSET, DAY_MARGIN_TOP } from '../dayLayout'
+import { DAY_HANDOFF_OFFSET, dayPositionScreenTop, findDayPosition } from '../dayLayout'
 import { ItemProps } from './types'
 
 export * from './types'
-
-// y-position of current scroll position relative to the bottom of the day container. (since we have inverted list it is bottom)
-export const useAbsoluteScrolledPositionToBottomOfDay = (listHeight: { value: number }, scrolledY: { value: number }, containerHeight: { value: number }, dayBottomMargin: number, dayTopOffset: number) => {
-  const absoluteScrolledPositionToBottomOfDay = useDerivedValue(() =>
-    listHeight.value + scrolledY.value - containerHeight.value - dayBottomMargin - dayTopOffset
-  , [listHeight, scrolledY, containerHeight, dayBottomMargin, dayTopOffset])
-
-  return absoluteScrolledPositionToBottomOfDay
-}
-
-export const useRelativeScrolledPositionToBottomOfDay = (
-  listHeight: { value: number },
-  scrolledY: { value: number },
-  daysPositions: { value: DaysPositions },
-  containerHeight: { value: number },
-  dayBottomMargin: number,
-  dayTopOffset: number,
-  createdAt?: number
-) => {
-  const dayMarginTop = useMemo(() => DAY_MARGIN_TOP, [])
-
-  const absoluteScrolledPositionToBottomOfDay = useAbsoluteScrolledPositionToBottomOfDay(listHeight, scrolledY, containerHeight, dayBottomMargin, dayTopOffset)
-
-  // find current day position by scrolled position
-  const currentDayPosition = useDerivedValue(() => {
-    'worklet'
-
-    // When createdAt is provided (called from AnimatedDayWrapper for a specific message),
-    // directly find the day position by createdAt without sorting the entire array.
-    // This avoids O(n log n) sorting and O(n) search for each message item.
-    if (createdAt != null) {
-      const values = Object.values(daysPositions.value)
-      for (let i = 0; i < values.length; i++)
-        if (values[i].createdAt === createdAt)
-          return values[i]
-    }
-
-    // Fallback: sort and search when createdAt is not provided (e.g., from DayAnimated)
-    const sortedArray = Object.values(daysPositions.value).sort((a, b) => {
-      'worklet'
-
-      return a.y - b.y
-    })
-    for (let i = 0; i < sortedArray.length; i++) {
-      const day = sortedArray[i]
-      const dayPosition = day.y + day.height
-      if (absoluteScrolledPositionToBottomOfDay.value < dayPosition || i === sortedArray.length - 1)
-        return day
-    }
-
-    return undefined
-  }, [daysPositions, absoluteScrolledPositionToBottomOfDay, createdAt])
-
-  const relativeScrolledPositionToBottomOfDay = useDerivedValue(() => {
-    const scrolledBottomY = listHeight.value + scrolledY.value - (
-      (currentDayPosition.value?.y ?? 0) +
-      (currentDayPosition.value?.height ?? 0) +
-      dayMarginTop
-    )
-
-    return scrolledBottomY
-  }, [listHeight, scrolledY, currentDayPosition, dayMarginTop])
-
-  return relativeScrolledPositionToBottomOfDay
-}
 
 const DayWrapper = <TMessage extends IMessage>(props: MessageProps<TMessage>) => {
   const {
@@ -114,22 +48,23 @@ const AnimatedDayWrapper = <TMessage extends IMessage>(props: ItemProps<TMessage
     ...rest
   } = props
 
-  const dayContainerHeight = useSharedValue(0)
-  const dayTopOffset = useMemo(() => 10, [])
-  const dayBottomMargin = useMemo(() => 10, [])
-
   const createdAt = useMemo(() =>
     new Date(props.currentMessage.createdAt).getTime()
   , [props.currentMessage.createdAt])
 
-  const relativeScrolledPositionToBottomOfDay = useRelativeScrolledPositionToBottomOfDay(listHeight, scrolledY, daysPositions, dayContainerHeight, dayBottomMargin, dayTopOffset, createdAt)
+  // On-screen Y of this day's separator. Infinity (treated as below the pin, i.e.
+  // visible) until the day has been measured.
+  const separatorScreenTop = useDerivedValue(() => {
+    'worklet'
 
-  const handleLayoutDayContainer = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
-    dayContainerHeight.value = nativeEvent.layout.height
-  }, [dayContainerHeight])
+    const day = findDayPosition(daysPositions.value, createdAt)
+    if (!day)
+      return Infinity
+
+    return dayPositionScreenTop(listHeight.value + scrolledY.value, day)
+  }, [daysPositions, listHeight, scrolledY, createdAt])
 
   const style = useAnimatedStyle(() => {
-    // rel = separatorScreenTop - DAY_MARGIN_TOP, so separatorScreenTop = rel + DAY_MARGIN_TOP.
     // The inline separator is the in-conversation date marker. It is shown while its
     // day is below the handoff line, and hidden once its day is the one the floating
     // header is actually rendering at the pin - a hard step (no fade) so the date
@@ -140,20 +75,16 @@ const AnimatedDayWrapper = <TMessage extends IMessage>(props: ItemProps<TMessage
     // the worklet picks the new stuck day instantly but the header's text only
     // updates ~1 frame later on the JS thread; until it does, this inline separator
     // stays up and shows the correct date, so the header never flashes the old one.
-    const separatorScreenTop = relativeScrolledPositionToBottomOfDay.value + DAY_MARGIN_TOP
-    const belowHandoff = separatorScreenTop > DAY_HANDOFF_OFFSET
+    const belowHandoff = separatorScreenTop.value > DAY_HANDOFF_OFFSET
     const headerShowsThisDay = floatingRenderedDate != null && floatingRenderedDate.value === createdAt
 
     return {
       opacity: belowHandoff || !headerShowsThisDay ? 1 : 0,
     }
-  }, [relativeScrolledPositionToBottomOfDay, floatingRenderedDate, createdAt])
+  }, [separatorScreenTop, floatingRenderedDate, createdAt])
 
   return (
-    <Animated.View
-      style={style}
-      onLayout={handleLayoutDayContainer}
-    >
+    <Animated.View style={style}>
       <DayWrapper<TMessage> {...rest as MessageProps<TMessage>} />
     </Animated.View>
   )

--- a/src/MessagesContainer/components/Item/index.tsx
+++ b/src/MessagesContainer/components/Item/index.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useMemo } from 'react'
 import { LayoutChangeEvent, View } from 'react-native'
-import Animated, { interpolate, useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated'
+import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated'
 import { Day } from '../../../Day'
 import { Message, MessageProps } from '../../../Message'
 import { IMessage } from '../../../Models'
 import { isSameDay } from '../../../utils'
 import { DaysPositions } from '../../types'
+import { DAY_HANDOFF_OFFSET, DAY_MARGIN_TOP } from '../dayLayout'
 import { ItemProps } from './types'
 
 export * from './types'
@@ -28,7 +29,7 @@ export const useRelativeScrolledPositionToBottomOfDay = (
   dayTopOffset: number,
   createdAt?: number
 ) => {
-  const dayMarginTop = useMemo(() => 5, [])
+  const dayMarginTop = useMemo(() => DAY_MARGIN_TOP, [])
 
   const absoluteScrolledPositionToBottomOfDay = useAbsoluteScrolledPositionToBottomOfDay(listHeight, scrolledY, containerHeight, dayBottomMargin, dayTopOffset)
 
@@ -109,6 +110,7 @@ const AnimatedDayWrapper = <TMessage extends IMessage>(props: ItemProps<TMessage
     scrolledY,
     daysPositions,
     listHeight,
+    floatingRenderedDate,
     ...rest
   } = props
 
@@ -126,24 +128,26 @@ const AnimatedDayWrapper = <TMessage extends IMessage>(props: ItemProps<TMessage
     dayContainerHeight.value = nativeEvent.layout.height
   }, [dayContainerHeight])
 
-  const style = useAnimatedStyle(() => ({
-    opacity: interpolate(
-      relativeScrolledPositionToBottomOfDay.value,
-      [
-        -dayTopOffset,
-        -0.0001,
-        0,
-        dayContainerHeight.value + dayTopOffset,
-      ],
-      [
-        0,
-        0,
-        1,
-        1,
-      ],
-      'clamp'
-    ),
-  }), [relativeScrolledPositionToBottomOfDay, dayContainerHeight, dayTopOffset])
+  const style = useAnimatedStyle(() => {
+    // rel = separatorScreenTop - DAY_MARGIN_TOP, so separatorScreenTop = rel + DAY_MARGIN_TOP.
+    // The inline separator is the in-conversation date marker. It is shown while its
+    // day is below the handoff line, and hidden once its day is the one the floating
+    // header is actually rendering at the pin - a hard step (no fade) so the date
+    // goes floating(1) <-> inline(1) at the same pixel with no dip and no duplicate.
+    //
+    // Hiding on `floatingRenderedDate` (the header's *rendered* date) rather than on
+    // position alone is what kills the 1-frame flash when scrolling into a newer day:
+    // the worklet picks the new stuck day instantly but the header's text only
+    // updates ~1 frame later on the JS thread; until it does, this inline separator
+    // stays up and shows the correct date, so the header never flashes the old one.
+    const separatorScreenTop = relativeScrolledPositionToBottomOfDay.value + DAY_MARGIN_TOP
+    const belowHandoff = separatorScreenTop > DAY_HANDOFF_OFFSET
+    const headerShowsThisDay = floatingRenderedDate != null && floatingRenderedDate.value === createdAt
+
+    return {
+      opacity: belowHandoff || !headerShowsThisDay ? 1 : 0,
+    }
+  }, [relativeScrolledPositionToBottomOfDay, floatingRenderedDate, createdAt])
 
   return (
     <Animated.View

--- a/src/MessagesContainer/components/Item/types.ts
+++ b/src/MessagesContainer/components/Item/types.ts
@@ -9,5 +9,9 @@ export interface ItemProps<TMessage extends IMessage> extends MessagesContainerP
   scrolledY: { value: number }
   daysPositions: { value: DaysPositions }
   listHeight: { value: number }
+  // The date currently rendered by the floating header (createdAt ms). Lets the
+  // inline separator stay visible until the header has actually rendered that day,
+  // covering the ~1-frame JS-thread lag on the floating header's text.
+  floatingRenderedDate?: { value: number | undefined }
   isDayAnimationEnabled?: boolean
 }

--- a/src/MessagesContainer/components/dayLayout.ts
+++ b/src/MessagesContainer/components/dayLayout.ts
@@ -1,0 +1,29 @@
+// Shared layout constants so the inline day separators (rendered inside the
+// list) and the floating sticky day header (the DayAnimated overlay) hand off
+// at exactly the same screen line. Keeping these in sync is what makes the
+// Telegram-style "push" read as a single sticky header with no duplicate badge
+// and no gap at the day boundary.
+
+// Screen-Y (px from the top of the list) where a day header sticks and where
+// the inline separator hands over to the floating header.
+export const DAY_PIN_OFFSET = 10
+
+// Vertical margin baked into the inline separator's relative-scroll math
+// (see useRelativeScrolledPositionToBottomOfDay). rel = separatorScreenTop - DAY_MARGIN_TOP.
+export const DAY_MARGIN_TOP = 5
+
+// Px range over which the inline separator cross-fades around the pin line as
+// the floating header takes over, to avoid a one-frame pop at the handoff.
+export const DAY_HANDOFF_FADE = 10
+
+// Vertical gap kept between the outgoing floating header and the incoming
+// separator's pill during the push, so the two dates don't touch.
+export const DAY_PUSH_GAP = 8
+
+// The separatorScreenTop value at which an inline separator's pill reaches the
+// floating header's pinned pill position, so they hand off at the exact same
+// spot. The inline pill sits `DAY_MARGIN_TOP` below its separatorScreenTop
+// (Day's container marginTop); the floating header overrides that margin to 0,
+// so its pinned pill sits `DAY_MARGIN_TOP` higher. They coincide at
+// separatorScreenTop = DAY_PIN_OFFSET - DAY_MARGIN_TOP.
+export const DAY_HANDOFF_OFFSET = DAY_PIN_OFFSET - DAY_MARGIN_TOP

--- a/src/MessagesContainer/components/dayLayout.ts
+++ b/src/MessagesContainer/components/dayLayout.ts
@@ -1,29 +1,49 @@
-// Shared layout constants so the inline day separators (rendered inside the
-// list) and the floating sticky day header (the DayAnimated overlay) hand off
-// at exactly the same screen line. Keeping these in sync is what makes the
-// Telegram-style "push" read as a single sticky header with no duplicate badge
-// and no gap at the day boundary.
+import { DaysPositions } from '../types'
 
-// Screen-Y (px from the top of the list) where a day header sticks and where
-// the inline separator hands over to the floating header.
+// Shared layout constants and math so the inline day separators (rendered inside
+// the list) and the floating sticky day header (the DayAnimated overlay) hand off
+// at exactly the same screen line. Keeping these in sync is what makes the
+// Telegram-style sticky push read as a single header with no duplicate badge and
+// no gap at the day boundary.
+
+// Screen-Y (px from the top of the list) where a day header sticks and where the
+// inline separator hands over to the floating header.
 export const DAY_PIN_OFFSET = 10
 
-// Vertical margin baked into the inline separator's relative-scroll math
-// (see useRelativeScrolledPositionToBottomOfDay). rel = separatorScreenTop - DAY_MARGIN_TOP.
+// Vertical margin baked into the inline separator's pill position (Day's container
+// marginTop). The inline pill renders this far below its separatorScreenTop.
 export const DAY_MARGIN_TOP = 5
-
-// Px range over which the inline separator cross-fades around the pin line as
-// the floating header takes over, to avoid a one-frame pop at the handoff.
-export const DAY_HANDOFF_FADE = 10
 
 // Vertical gap kept between the outgoing floating header and the incoming
 // separator's pill during the push, so the two dates don't touch.
 export const DAY_PUSH_GAP = 8
 
 // The separatorScreenTop value at which an inline separator's pill reaches the
-// floating header's pinned pill position, so they hand off at the exact same
-// spot. The inline pill sits `DAY_MARGIN_TOP` below its separatorScreenTop
-// (Day's container marginTop); the floating header overrides that margin to 0,
-// so its pinned pill sits `DAY_MARGIN_TOP` higher. They coincide at
+// floating header's pinned pill. The inline pill sits DAY_MARGIN_TOP below its
+// separatorScreenTop; the floating header overrides that margin to 0, so its
+// pinned pill sits DAY_MARGIN_TOP higher. They coincide - and hand off - at
 // separatorScreenTop = DAY_PIN_OFFSET - DAY_MARGIN_TOP.
 export const DAY_HANDOFF_OFFSET = DAY_PIN_OFFSET - DAY_MARGIN_TOP
+
+type DayPosition = DaysPositions[string]
+
+// On-screen Y of a day separator's top edge. `scrolledTop` is `listHeight + scrolledY`.
+// (Inverted list: a separator is above the pin when this is <= DAY_HANDOFF_OFFSET.)
+export const dayPositionScreenTop = (scrolledTop: number, day: DayPosition) => {
+  'worklet'
+
+  return scrolledTop - (day.y + day.height)
+}
+
+// The measured position of the day with the given createdAt (ms), or undefined if
+// that day hasn't been laid out yet.
+export const findDayPosition = (positions: DaysPositions, createdAt: number): DayPosition | undefined => {
+  'worklet'
+
+  const values = Object.values(positions)
+  for (let i = 0; i < values.length; i++)
+    if (values[i].createdAt === createdAt)
+      return values[i]
+
+  return undefined
+}

--- a/src/MessagesContainer/index.tsx
+++ b/src/MessagesContainer/index.tsx
@@ -58,6 +58,14 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
   const listHeight = useSharedValue(0)
   const contentHeight = useSharedValue(0)
   const scrolledY = useSharedValue(0)
+  // The date (createdAt ms) the floating day header is currently rendering. Used to
+  // keep the inline separator visible until the header's text has caught up, hiding
+  // the 1-frame JS-thread lag of the header on each day change.
+  const floatingRenderedDate = useSharedValue<number | undefined>(undefined)
+  // true while the user is actively scrolling (finger down dragging or momentum
+  // running). Drives the floating day header visibility so it stays opaque for the
+  // whole gesture and only fades once scrolling fully stops.
+  const isScrollActive = useSharedValue(false)
 
   const renderTypingIndicator = useCallback(() => {
     if (renderTypingIndicatorProp)
@@ -211,6 +219,7 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
         scrolledY,
         daysPositions,
         listHeight,
+        floatingRenderedDate,
         isDayAnimationEnabled,
       }
 
@@ -220,7 +229,7 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
     }
 
     return null
-  }, [messages, restProps, isInverted, scrolledY, daysPositions, listHeight, isDayAnimationEnabled, user])
+  }, [messages, restProps, isInverted, scrolledY, daysPositions, listHeight, floatingRenderedDate, isDayAnimationEnabled, user])
 
   const emptyContent = useMemo(() => {
     if (!renderChatEmptyProp)
@@ -388,7 +397,21 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
 
       runOnJS(handleOnScroll)(event)
     },
-  }, [handleOnScroll])
+    onBeginDrag: () => {
+      isScrollActive.value = true
+    },
+    onEndDrag: () => {
+      // Momentum (if any) re-asserts isScrollActive via onMomentumBegin within the
+      // header's fade-out delay, so a flick keeps the header visible.
+      isScrollActive.value = false
+    },
+    onMomentumBegin: () => {
+      isScrollActive.value = true
+    },
+    onMomentumEnd: () => {
+      isScrollActive.value = false
+    },
+  }, [handleOnScroll, isScrollActive])
 
   // removes unrendered days positions when messages are added/removed
   useEffect(() => {
@@ -455,8 +478,9 @@ export const MessagesContainer = <TMessage extends IMessage>(props: MessagesCont
           scrolledY={scrolledY}
           daysPositions={daysPositions}
           listHeight={listHeight}
+          isScrollActive={isScrollActive}
+          floatingRenderedDate={floatingRenderedDate}
           renderDay={renderDayProp}
-          messages={messages}
           isLoading={loadEarlierMessagesProps?.isLoading ?? false}
           dateFormat={props.dateFormat}
           dateFormatCalendar={props.dateFormatCalendar}

--- a/src/__tests__/DayAnimated.test.tsx
+++ b/src/__tests__/DayAnimated.test.tsx
@@ -3,11 +3,12 @@ import { View, Text } from 'react-native'
 import { render } from '@testing-library/react-native'
 import { DayProps } from '../Day'
 import { DayAnimated } from '../MessagesContainer/components/DayAnimated'
-import { DEFAULT_TEST_MESSAGE } from './data'
 
 const mockDaysPositions = { value: {} }
 const mockScrolledY = { value: 0 }
 const mockListHeight = { value: 800 }
+const mockIsScrollActive = { value: false }
+const mockFloatingRenderedDate = { value: undefined }
 
 describe('DayAnimated', () => {
   it('should render DayAnimated with default Day component', () => {
@@ -16,7 +17,8 @@ describe('DayAnimated', () => {
         scrolledY={mockScrolledY}
         daysPositions={mockDaysPositions}
         listHeight={mockListHeight}
-        messages={[DEFAULT_TEST_MESSAGE]}
+        isScrollActive={mockIsScrollActive}
+        floatingRenderedDate={mockFloatingRenderedDate}
         isLoading={false}
       />
     )
@@ -35,7 +37,8 @@ describe('DayAnimated', () => {
         scrolledY={mockScrolledY}
         daysPositions={mockDaysPositions}
         listHeight={mockListHeight}
-        messages={[DEFAULT_TEST_MESSAGE]}
+        isScrollActive={mockIsScrollActive}
+        floatingRenderedDate={mockFloatingRenderedDate}
         isLoading={false}
         renderDay={customRenderDay}
       />


### PR DESCRIPTION
Reworks the floating day header (`DayAnimated`) and the inline day separators so the date reads as a single sticky header that slides between days, fixing several glitches while scrolling. Adds a dedicated example to exercise it, and tidies the implementation.

## Fixes (the animation)
- **Scroll-driven slide** - the header is positioned off the next (newer) day's separator, so an older day slides down from the top edge to the pin pixel by pixel, and a newer day pushes the current one up and off. A `DAY_PUSH_GAP` keeps a margin between the two date pills.
- **Hard handoff, no cross-fade** - the inline separator and the header hard-cut at the shared `DAY_HANDOFF_OFFSET` line, so the date goes floating <-> inline at the same pixel with no dip to 0 and no fading duplicate.
- **Gesture-driven visibility** - the header fades in/out from the scroll begin/end drag and momentum events (`isScrollActive`) instead of per-scroll-delta idle timers, so it stays fully opaque through slow drags and short pauses.
- **No wrong-date flash** - the header publishes the date it is actually rendering (`floatingRenderedDate`) and is hidden for the ~1 frame its React-state text lags the worklet; the inline separator covers that frame. Removes the brief flash of the previous date when scrolling into a newer day.
- **Stable stuck-day selection** - days are ordered by `createdAt` instead of measured `y` (which jitters mid-scroll), so the selection can't jump to the wrong day.
- **Top of history** - the header hard-hides when no day is stuck (the "Load earlier" button scrolls in) and tucks above the top while loading, with no duplicate over the loader.

## Example
- New **Day Animated** example: a multi-day chat with a working "Load earlier" that prepends older days, for exercising the header, day boundaries and the top-of-history loader. Wired into the Explore list and chat routes.
- Chat header: chevron-only back button, centered title.

## Refactor
- DRY the geometry into `dayLayout` helpers (`dayPositionScreenTop`, `findDayPosition`), shared by `DayAnimated` and `Item`.
- Drop the legacy position hooks in `Item` for one direct `separatorScreenTop` value.
- Extract the fade into `useScrollGatedOpacity` and the debug switches/overlay into a `DAY_DEBUG` config + `useDayDebugOverlay` hook for future work.
- Remove dead `DAY_HANDOFF_FADE`; fix `DayAnimated.test.tsx` to pass the now-required props.

Shared layout/behaviour is documented in `docs/DAY_ANIMATED_SPEC.md`. Validated on the Android emulator across both scroll directions, day boundaries, and the Load earlier loader.